### PR TITLE
Fix blank screen when Active Tasks Only filter has no results

### DIFF
--- a/src/views/TasksView.vue
+++ b/src/views/TasksView.vue
@@ -400,13 +400,15 @@ function isColVisible(key: string): boolean {
     />
 
     <EmptyState
-      v-else-if="store.tasks.length === 0"
+      v-else-if="filteredTasks.length === 0"
       icon="&#128203;"
-      message="No tasks. Attach a project to start computing."
+      :message="activeTasksOnly
+        ? 'No active tasks right now.'
+        : 'No tasks. Attach a project to start computing.'"
     />
 
     <DataTable
-      v-if="filteredTasks.length > 0"
+      v-else
       :columns="columns"
       :sort-key="sortKey"
       :sort-dir="sortDir"


### PR DESCRIPTION
## Summary

- When **Active Tasks Only** was toggled on but no tasks were actively computing (all in Waiting/Downloading/Uploading state), the view rendered a completely blank screen with no message
- Root cause: `EmptyState` checked `store.tasks.length` (raw data) while `DataTable` used `v-if="filteredTasks.length > 0"` — the intermediate case where tasks exist but are all filtered out was never handled
- Fix: unify the empty check to `filteredTasks`, show a context-aware message ("No active tasks right now." vs "No tasks. Attach a project."), and turn `DataTable` into a `v-else` so the chain is always exhaustive

## Test plan

- [ ] With tasks in Waiting state, toggle **Active Tasks Only** → should show "No active tasks right now." instead of a blank screen
- [ ] With no projects attached, toggle off **Active Tasks Only** → should show "No tasks. Attach a project to start computing."
- [ ] With actively running tasks, toggle **Active Tasks Only** → tasks should still appear in the table

🤖 Generated with [Claude Code](https://claude.com/claude-code)