### PR TITLE
Add Launch at Login option to Manager Options

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@tauri-apps/api": "^2",
+    "@tauri-apps/plugin-autostart": "^2",
     "@tauri-apps/plugin-notification": "^2.3.3",
     "@tauri-apps/plugin-opener": "^2",
     "@tauri-apps/plugin-process": "^2.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@tauri-apps/api':
         specifier: ^2
         version: 2.10.1
+      '@tauri-apps/plugin-autostart':
+        specifier: ^2
+        version: 2.5.1
       '@tauri-apps/plugin-notification':
         specifier: ^2.3.3
         version: 2.3.3
@@ -696,6 +699,9 @@ packages:
     resolution: {integrity: sha512-ZwT0T+7bw4+DPCSWzmviwq5XbXlM0cNoleDKOYPFYqcZqeKY31KlpoMW/MOON/tOFBPgi31a2v3w9gliqwL2+Q==}
     engines: {node: '>= 10'}
     hasBin: true
+
+  '@tauri-apps/plugin-autostart@2.5.1':
+    resolution: {integrity: sha512-zS/xx7yzveCcotkA+8TqkI2lysmG2wvQXv2HGAVExITmnFfHAdj1arGsbbfs3o6EktRHf6l34pJxc3YGG2mg7w==}
 
   '@tauri-apps/plugin-notification@2.3.3':
     resolution: {integrity: sha512-Zw+ZH18RJb41G4NrfHgIuofJiymusqN+q8fGUIIV7vyCH+5sSn5coqRv/MWB9qETsUs97vmU045q7OyseCV3Qg==}
@@ -1823,6 +1829,10 @@ snapshots:
       '@tauri-apps/cli-win32-arm64-msvc': 2.10.0
       '@tauri-apps/cli-win32-ia32-msvc': 2.10.0
       '@tauri-apps/cli-win32-x64-msvc': 2.10.0
+
+  '@tauri-apps/plugin-autostart@2.5.1':
+    dependencies:
+      '@tauri-apps/api': 2.10.1
 
   '@tauri-apps/plugin-notification@2.3.3':
     dependencies:

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -28,6 +28,7 @@ tauri-plugin-single-instance = "2.4.0"
 tauri-plugin-cli = "2.4.1"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
 tauri-plugin-process = "2"
+tauri-plugin-autostart = "2"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full", "test-util"] }

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -9,6 +9,9 @@
     "core:tray:default",
     "notification:default",
     "process:default",
-    "core:window:allow-set-theme"
+    "core:window:allow-set-theme",
+    "autostart:allow-enable",
+    "autostart:allow-disable",
+    "autostart:allow-is-enabled"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -897,6 +897,10 @@ pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_notification::init())
+        .plugin(tauri_plugin_autostart::init(
+            tauri_plugin_autostart::MacosLauncher::LaunchAgent,
+            Some(vec!["--autostart"]),
+        ))
         .plugin(tauri_plugin_cli::init())
         .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_single_instance::init(|app, _argv, _cwd| {

--- a/src/components/ManagerOptionsDialog.vue
+++ b/src/components/ManagerOptionsDialog.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, watch } from "vue";
+import { enable, disable, isEnabled } from "@tauri-apps/plugin-autostart";
 import { useManagerSettingsStore } from "../stores/managerSettings";
 
 const props = defineProps<{ open: boolean }>();
@@ -7,18 +8,25 @@ const emit = defineEmits<{ close: [] }>();
 
 const store = useManagerSettingsStore();
 const form = ref({ ...store.settings });
+const launchAtLogin = ref(false);
 
 watch(
   () => props.open,
-  (isOpen) => {
+  async (isOpen) => {
     if (isOpen) {
       form.value = { ...store.settings };
+      launchAtLogin.value = await isEnabled();
     }
   },
 );
 
-function save() {
+async function save() {
   Object.assign(store.settings, form.value);
+  if (launchAtLogin.value) {
+    await enable();
+  } else {
+    await disable();
+  }
   emit("close");
 }
 </script>
@@ -94,6 +102,13 @@ function save() {
             <label class="option-toggle">
               <input type="checkbox" v-model="form.startMinimizedToTray" />
               <span>Start minimized to system tray</span>
+            </label>
+          </div>
+
+          <div class="option-group">
+            <label class="option-toggle">
+              <input type="checkbox" v-model="launchAtLogin" />
+              <span>Launch at login</span>
             </label>
           </div>
         </div>


### PR DESCRIPTION
## Summary

- Adds **Launch at Login** checkbox to Manager Options dialog
- Uses `tauri-plugin-autostart` to register a macOS LaunchAgent at `~/Library/LaunchAgents/com.github.aufarzakiev.fresco.plist`
- The checkbox reads the current OS state (`isEnabled()`) every time the dialog opens, and applies the change (`enable()`/`disable()`) on Save
- Passes the existing `--autostart` CLI flag to the LaunchAgent so the app starts hidden to the system tray when launched at login

## Changes

| File | Change |
|---|---|
| `src-tauri/Cargo.toml` | Add `tauri-plugin-autostart = "2"` |
| `src-tauri/src/lib.rs` | Register plugin with `MacosLauncher::LaunchAgent` |
| `src-tauri/capabilities/default.json` | Add `autostart:allow-*` permissions |
| `package.json` + `pnpm-lock.yaml` | Add `@tauri-apps/plugin-autostart ^2` |
| `src/components/ManagerOptionsDialog.vue` | Add checkbox + async `isEnabled`/`enable`/`disable` |

## Test plan

- [ ] Open Manager Options → "Launch at Login" checkbox reflects current state
- [ ] Enable it, save → app appears in macOS Login Items (`System Settings → General → Login Items`)
- [ ] Restart Mac → Fresco starts automatically, hidden to tray
- [ ] Disable it, save → removed from Login Items

---

**Note:** Rebased on latest `master` to resolve conflicts in `Cargo.toml` and `capabilities/default.json`. All tests pass (`cargo test`: 38/38, `npm run build`: clean).