### PR TITLE
fix: restore window on Dock icon click when minimized (macOS)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1050,6 +1050,16 @@ pub fn run() {
             updater::install_update,
             updater::cleanup_old_binary,
         ])
-        .run(tauri::generate_context!())
-        .expect("error while running tauri application");
+        .build(tauri::generate_context!())
+        .expect("error while building tauri application")
+        .run(|_app_handle, _event| {
+            #[cfg(target_os = "macos")]
+            if let tauri::RunEvent::Reopen { .. } = _event {
+                if let Some(window) = _app_handle.get_webview_window("main") {
+                    let _ = window.show();
+                    let _ = window.unminimize();
+                    let _ = window.set_focus();
+                }
+            }
+        });
 }


### PR DESCRIPTION
## Summary

- Handle `RunEvent::Reopen` to show, unminimize and focus the main window when the user clicks the Dock icon on macOS
- Previously the click was silently ignored — `CloseRequested` hides the window instead of quitting, so the app became unreachable until restarted
- `RunEvent::Reopen` is macOS-only and never fires on Linux/Windows, no cross-platform impact

## Test plan

- [ ] Launch app, minimize via yellow button → click Dock icon → window restores
- [ ] Launch app, close via red button → click Dock icon → window shows
- [ ] Normal quit via system tray still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)