### PR TITLE
fix: prevent empty table flicker on Event Log page

### DIFF
--- a/src/views/MessagesView.vue
+++ b/src/views/MessagesView.vue
@@ -238,7 +238,7 @@ onUnmounted(() => {
     </div>
 
     <EmptyState
-      v-if="!store.loading && sortedMessages.length === 0"
+      v-if="sortedMessages.length === 0"
       icon="&#x1f4ac;"
       message="No messages to display."
     />


### PR DESCRIPTION
## Summary
- Fixed flickering empty table headers on the Event Log page when no messages are present
- The `EmptyState` condition included a `!store.loading` guard, so during each polling cycle (`loading` toggles true→false), the empty `DataTable` briefly rendered its column headers before `EmptyState` reappeared
- Removed the `!store.loading` check — now `EmptyState` shows immediately when there are no messages

## Test plan
- [ ] Open Event Log with no messages — verify "No messages to display" shows without any flicker

🤖 Generated with [Claude Code](https://claude.com/claude-code)