### PR TITLE
feat: split statistics into Total Credit and Average Credit charts

### DIFF
--- a/src/components/StatisticsChart.vue
+++ b/src/components/StatisticsChart.vue
@@ -11,10 +11,10 @@ const props = defineProps<{
 }>();
 
 const seriesConfig = [
-  { key: "user_total_credit" as const, label: "User Total", color: "#3b82f6" },
-  { key: "user_expavg_credit" as const, label: "User Avg", color: "#8b5cf6" },
-  { key: "host_total_credit" as const, label: "Host Total", color: "#10b981" },
-  { key: "host_expavg_credit" as const, label: "Host Avg", color: "#f59e0b" },
+  { key: "user_total_credit" as const, label: "User", color: "#3b82f6" },
+  { key: "user_expavg_credit" as const, label: "User", color: "#3b82f6" },
+  { key: "host_total_credit" as const, label: "Host", color: "#10b981" },
+  { key: "host_expavg_credit" as const, label: "Host", color: "#10b981" },
 ];
 
 const hoveredPoint = ref<{

--- a/src/views/StatisticsView.vue
+++ b/src/views/StatisticsView.vue
@@ -15,15 +15,7 @@ type ViewMode = "single" | "all" | "separate" | "total";
 const viewMode = ref<ViewMode>("single");
 const selectedProjectUrl = ref("");
 
-const totalSeriesConfig = [
-  { key: "user_total_credit" as const, label: "User", color: "#3b82f6" },
-  { key: "host_total_credit" as const, label: "Host", color: "#10b981" },
-];
-
-const avgSeriesConfig = [
-  { key: "user_expavg_credit" as const, label: "User", color: "#8b5cf6" },
-  { key: "host_expavg_credit" as const, label: "Host", color: "#f59e0b" },
-];
+const actorColors = { user: "#3b82f6", host: "#10b981" };
 
 const enabledActors = ref<Set<string>>(new Set(["user", "host"]));
 
@@ -184,7 +176,7 @@ onUnmounted(() => {
             :checked="enabledActors.has('user')"
             @change="toggleActor('user')"
           />
-          <span class="series-swatch" :style="{ background: '#3b82f6' }"></span>
+          <span class="series-swatch" :style="{ background: actorColors.user }"></span>
           <span class="series-label">User</span>
         </label>
         <label class="series-toggle">
@@ -193,7 +185,7 @@ onUnmounted(() => {
             :checked="enabledActors.has('host')"
             @change="toggleActor('host')"
           />
-          <span class="series-swatch" :style="{ background: '#10b981' }"></span>
+          <span class="series-swatch" :style="{ background: actorColors.host }"></span>
           <span class="series-label">Host</span>
         </label>
       </div>


### PR DESCRIPTION
## Summary
- Split the single statistics chart into two: **Total Credit** and **Average Credit**, each with its own Y axis
- Average credit values are now clearly visible instead of being flattened by the total credit scale
- Simplified toggles from 4 series checkboxes to 2 actor toggles (User / Host) that control both charts
- Consistent colors: User = blue, Host = green across both charts

## Test plan
- [ ] Open Statistics → Single Project: verify two charts appear with independent Y scales
- [ ] Toggle User/Host checkboxes: both charts update accordingly
- [ ] Check All Together, All Separate, Total modes — all show two charts
- [ ] Verify Average Credit chart shows meaningful line shapes (not flat)

Part of #14

🤖 Reviewed with Codex before submission.