### PR TITLE
fix: remove duplicate "Total" tab from Statistics page

### DIFF
--- a/src/views/StatisticsView.vue
+++ b/src/views/StatisticsView.vue
@@ -10,7 +10,7 @@ import StatisticsChart from "../components/StatisticsChart.vue";
 const store = useStatisticsStore();
 const projectsStore = useProjectsStore();
 
-type ViewMode = "single" | "all" | "separate" | "total";
+type ViewMode = "single" | "all" | "separate";
 
 const viewMode = ref<ViewMode>("single");
 const selectedProjectUrl = ref("");
@@ -76,7 +76,7 @@ const chartData = computed(() => {
     if (!activeProject.value) return null;
     const stats = activeProject.value.daily_statistics;
     return stats.length === 0 ? null : stats;
-  } else if (viewMode.value === "all" || viewMode.value === "total") {
+  } else if (viewMode.value === "all") {
     const stats = mergeAllProjects();
     return stats.length === 0 ? null : stats;
   }
@@ -140,12 +140,6 @@ onUnmounted(() => {
           @click="viewMode = 'separate'"
         >
           All Separate
-        </button>
-        <button
-          :class="['segment', { active: viewMode === 'total' }]"
-          @click="viewMode = 'total'"
-        >
-          Total
         </button>
       </div>
 


### PR DESCRIPTION
## Summary
- Remove the "Total" tab which produced identical output to "All Together" (both called `mergeAllProjects`)
- Statistics page now has 3 tabs: Single Project, All Together, All Separate

## Test plan
- [ ] Open Statistics — verify 3 tabs visible
- [ ] "All Together" shows merged data from all projects
- [ ] "All Separate" shows individual charts per project

Part of #14

🤖 Reviewed with Codex before submission.