### PR TITLE
fix(ui): replace gear icon with columns icon in column picker

### DIFF
--- a/src/views/ProjectsView.vue
+++ b/src/views/ProjectsView.vue
@@ -371,9 +371,11 @@ function isColVisible(key: string): boolean {
       <button class="btn btn-primary" @click="showAttachWizard = true">Add Project</button>
       <button class="btn" @click="showAcctMgr = true">Account Manager</button>
       <Tooltip text="Columns">
-        <button class="btn btn-icon" @click="showColumns = true">
-          <svg viewBox="0 0 20 20" fill="currentColor" width="16" height="16">
-            <path fill-rule="evenodd" d="M11.49 3.17c-.38-1.56-2.6-1.56-2.98 0a1.532 1.532 0 01-2.286.948c-1.372-.836-2.942.734-2.106 2.106.54.886.061 2.042-.947 2.287-1.561.379-1.561 2.6 0 2.978a1.532 1.532 0 01.947 2.287c-.836 1.372.734 2.942 2.106 2.106a1.532 1.532 0 012.287.947c.379 1.561 2.6 1.561 2.978 0a1.533 1.533 0 012.287-.947c1.372.836 2.942-.734 2.106-2.106a1.533 1.533 0 01.947-2.287c1.561-.379 1.561-2.6 0-2.978a1.532 1.532 0 01-.947-2.287c.836-1.372-.734-2.942-2.106-2.106a1.532 1.532 0 01-2.287-.947zM10 13a3 3 0 100-6 3 3 0 000 6z" clip-rule="evenodd" />
+        <button class="btn-columns" @click="showColumns = true">
+          <svg viewBox="0 0 16 16" fill="currentColor" width="14" height="14">
+            <rect x="1" y="2" width="3" height="12" rx="0.5" />
+            <rect x="6.5" y="2" width="3" height="12" rx="0.5" />
+            <rect x="12" y="2" width="3" height="12" rx="0.5" />
           </svg>
         </button>
       </Tooltip>
@@ -627,12 +629,21 @@ function isColVisible(key: string): boolean {
   text-align: right;
 }
 
-.btn-icon {
+.btn-columns {
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 6px;
-  min-width: 32px;
+  padding: 4px;
+  border: none;
+  background: none;
+  color: var(--color-text-tertiary);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: color 0.15s;
+}
+
+.btn-columns:hover {
+  color: var(--color-text-primary);
 }
 
 /* Content layout */

--- a/src/views/TasksView.vue
+++ b/src/views/TasksView.vue
@@ -404,9 +404,11 @@ function isColVisible(key: string): boolean {
         </button>
       </template>
       <Tooltip text="Columns">
-        <button class="btn btn-icon" @click="showColumns = true">
-          <svg viewBox="0 0 20 20" fill="currentColor" width="16" height="16">
-            <path fill-rule="evenodd" d="M11.49 3.17c-.38-1.56-2.6-1.56-2.98 0a1.532 1.532 0 01-2.286.948c-1.372-.836-2.942.734-2.106 2.106.54.886.061 2.042-.947 2.287-1.561.379-1.561 2.6 0 2.978a1.532 1.532 0 01.947 2.287c-.836 1.372.734 2.942 2.106 2.106a1.532 1.532 0 012.287.947c.379 1.561 2.6 1.561 2.978 0a1.533 1.533 0 012.287-.947c1.372.836 2.942-.734 2.106-2.106a1.533 1.533 0 01.947-2.287c1.561-.379 1.561-2.6 0-2.978a1.532 1.532 0 01-.947-2.287c.836-1.372-.734-2.942-2.106-2.106a1.532 1.532 0 01-2.287-.947zM10 13a3 3 0 100-6 3 3 0 000 6z" clip-rule="evenodd" />
+        <button class="btn-columns" @click="showColumns = true">
+          <svg viewBox="0 0 16 16" fill="currentColor" width="14" height="14">
+            <rect x="1" y="2" width="3" height="12" rx="0.5" />
+            <rect x="6.5" y="2" width="3" height="12" rx="0.5" />
+            <rect x="12" y="2" width="3" height="12" rx="0.5" />
           </svg>
         </button>
       </Tooltip>
@@ -590,11 +592,20 @@ function isColVisible(key: string): boolean {
   border-color: var(--color-accent);
 }
 
-.btn-icon {
+.btn-columns {
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 6px;
-  min-width: 32px;
+  padding: 4px;
+  border: none;
+  background: none;
+  color: var(--color-text-tertiary);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: color 0.15s;
+}
+
+.btn-columns:hover {
+  color: var(--color-text-primary);
 }
 </style>

--- a/src/views/TransfersView.vue
+++ b/src/views/TransfersView.vue
@@ -236,9 +236,11 @@ function isColVisible(key: string): boolean {
         <button class="btn btn-danger" :disabled="actionBusy" @click="confirmAbort = true">Abort</button>
       </template>
       <Tooltip text="Columns">
-        <button class="btn btn-icon" @click="showColumns = true">
-          <svg viewBox="0 0 20 20" fill="currentColor" width="16" height="16">
-            <path fill-rule="evenodd" d="M11.49 3.17c-.38-1.56-2.6-1.56-2.98 0a1.532 1.532 0 01-2.286.948c-1.372-.836-2.942.734-2.106 2.106.54.886.061 2.042-.947 2.287-1.561.379-1.561 2.6 0 2.978a1.532 1.532 0 01.947 2.287c-.836 1.372.734 2.942 2.106 2.106a1.532 1.532 0 012.287.947c.379 1.561 2.6 1.561 2.978 0a1.533 1.533 0 012.287-.947c1.372.836 2.942-.734 2.106-2.106a1.533 1.533 0 01.947-2.287c1.561-.379 1.561-2.6 0-2.978a1.532 1.532 0 01-.947-2.287c.836-1.372-.734-2.942-2.106-2.106a1.532 1.532 0 01-2.287-.947zM10 13a3 3 0 100-6 3 3 0 000 6z" clip-rule="evenodd" />
+        <button class="btn-columns" @click="showColumns = true">
+          <svg viewBox="0 0 16 16" fill="currentColor" width="14" height="14">
+            <rect x="1" y="2" width="3" height="12" rx="0.5" />
+            <rect x="6.5" y="2" width="3" height="12" rx="0.5" />
+            <rect x="12" y="2" width="3" height="12" rx="0.5" />
           </svg>
         </button>
       </Tooltip>
@@ -392,11 +394,20 @@ function isColVisible(key: string): boolean {
   color: var(--color-text-primary);
 }
 
-.btn-icon {
+.btn-columns {
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 6px;
-  min-width: 32px;
+  padding: 4px;
+  border: none;
+  background: none;
+  color: var(--color-text-tertiary);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: color 0.15s;
+}
+
+.btn-columns:hover {
+  color: var(--color-text-primary);
 }
 </style>


### PR DESCRIPTION
## Summary
- Replace gear/cog SVG icon with a columns icon (3 vertical bars) in the column picker button across Tasks, Projects, and Transfers views
- Change button style from `.btn .btn-icon` to ghost `.btn-columns` (no background/border, hover color change only)
- Makes the button visually distinct from settings and less prominent than action buttons

Closes #16

## Test plan
- [ ] Open Tasks view — column picker button shows 3 vertical bars icon (not gear)
- [ ] Open Projects view — same column icon
- [ ] Open Transfers view — same column icon
- [ ] Hover over the icon — color changes from tertiary to primary
- [ ] Click the icon — column customization dialog opens as before

🤖 Reviewed with Codex before submission.