### PR TITLE
fix: replace navigator.platform with Tauri compile-time platform detection

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -905,6 +905,26 @@ fn get_build_time() -> String {
         .to_string()
 }
 
+#[tauri::command]
+fn get_platform() -> &'static str {
+    if cfg!(target_os = "windows") {
+        "windows"
+    } else if cfg!(target_os = "macos") {
+        "macos"
+    } else {
+        "linux"
+    }
+}
+
+#[tauri::command]
+fn get_arch() -> &'static str {
+    if cfg!(target_arch = "aarch64") {
+        "arm64"
+    } else {
+        "x86_64"
+    }
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
@@ -1053,6 +1073,8 @@ pub fn run() {
             get_message_count,
             get_daily_xfer_history,
             get_build_time,
+            get_platform,
+            get_arch,
             updater::download_update,
             updater::update_now,
             updater::install_update,

--- a/src/App.vue
+++ b/src/App.vue
@@ -15,6 +15,7 @@ import UpdateBanner from "./components/UpdateBanner.vue";
 import Tooltip from "./components/Tooltip.vue";
 import { useWindowState } from "./composables/useWindowState";
 import { useUpdateCheck } from "./composables/useUpdateCheck";
+import { getOS, defaultDataDir } from "./composables/usePlatform";
 import { notifyConnectionLost } from "./composables/useNotifications";
 import { useTasksStore } from "./stores/tasks";
 import { useProjectsStore } from "./stores/projects";
@@ -79,13 +80,6 @@ const { updateAvailable, dismissed, updateOnExit, downloaded, downloading, check
 
 // ── Auto-connect to local BOINC client on startup ───────────────
 
-function defaultDataDir(): string {
-  const platform = navigator.platform.toLowerCase();
-  if (platform.includes("win")) return "C:\\ProgramData\\BOINC";
-  if (platform.includes("mac")) return "/Library/Application Support/BOINC Data";
-  return "/var/lib/boinc-client";
-}
-
 function startAllPolling() {
   tasksStore.startPolling();
   projectsStore.startPolling();
@@ -99,7 +93,7 @@ function startAllPolling() {
 }
 
 async function autoConnect() {
-  const dataDir = defaultDataDir();
+  const dataDir = defaultDataDir(await getOS());
   loadingStatus.value = "Connecting to a local BOINC...";
   await connection.connectToLocal(dataDir);
 

--- a/src/composables/usePlatform.ts
+++ b/src/composables/usePlatform.ts
@@ -1,0 +1,30 @@
+import { invoke } from "@tauri-apps/api/core";
+
+export type OS = "windows" | "macos" | "linux";
+export type Arch = "arm64" | "x86_64";
+
+export function getOS(): Promise<OS> {
+  return invoke("get_platform");
+}
+
+export function getArch(): Promise<Arch> {
+  return invoke("get_arch");
+}
+
+export function defaultDataDir(os: OS): string {
+  if (os === "windows") return "C:\\ProgramData\\BOINC";
+  if (os === "macos") return "/Library/Application Support/BOINC Data";
+  return "/var/lib/boinc-client";
+}
+
+export function defaultClientDir(os: OS): string {
+  if (os === "windows") return "C:\\Program Files\\BOINC";
+  if (os === "macos") return "/Applications/BOINCManager.app/Contents/Resources";
+  return "/usr/bin";
+}
+
+export function platformAssetPattern(os: OS, arch: Arch): string {
+  const osLabel = { windows: "Windows", macos: "macOS", linux: "Linux" }[os];
+  const archLabel = { arm64: "ARM64", x86_64: "x86_64" }[arch];
+  return `${osLabel}_${archLabel}`;
+}

--- a/src/composables/useUpdateCheck.ts
+++ b/src/composables/useUpdateCheck.ts
@@ -1,6 +1,7 @@
 import { ref } from "vue";
 import { invoke } from "@tauri-apps/api/core";
 import { useManagerSettingsStore } from "../stores/managerSettings";
+import { getOS, getArch, platformAssetPattern } from "./usePlatform";
 
 const GITHUB_API_URL =
   "https://api.github.com/repos/AufarZakiev/Fresco/releases/latest";
@@ -38,31 +39,9 @@ invoke<string>("get_build_time").then((bt) => {
   buildTime.value = bt;
 });
 
-function getPlatformAssetPattern(): string {
-  const platform = navigator.platform.toLowerCase();
-  const ua = navigator.userAgent.toLowerCase();
-
-  if (platform.includes("win")) {
-    if (ua.includes("arm") || ua.includes("aarch64")) {
-      return "Windows_ARM64";
-    }
-    return "Windows_x86_64";
-  }
-  if (platform.includes("mac")) {
-    if (ua.includes("arm") || platform.includes("arm")) {
-      return "macOS_ARM64";
-    }
-    return "macOS_x86_64";
-  }
-  // Linux
-  if (ua.includes("aarch64") || ua.includes("arm64")) {
-    return "Linux_ARM64";
-  }
-  return "Linux_x86_64";
-}
-
-function matchAsset(assets: GitHubAsset[]): string {
-  const pattern = getPlatformAssetPattern();
+async function matchAsset(assets: GitHubAsset[]): Promise<string> {
+  const [os, arch] = await Promise.all([getOS(), getArch()]);
+  const pattern = platformAssetPattern(os, arch);
   const match = assets.find((a) => a.name.includes(pattern));
   return match?.browser_download_url ?? "";
 }
@@ -125,7 +104,7 @@ export async function checkForUpdates(force = false) {
       updateAvailable.value = true;
       releaseDate.value = release.published_at;
       releaseUrl.value = release.html_url;
-      assetUrl.value = matchAsset(release.assets);
+      assetUrl.value = await matchAsset(release.assets);
       dismissed.value = isDismissed(release.published_at);
     } else {
       updateAvailable.value = false;

--- a/src/mocks/handler.ts
+++ b/src/mocks/handler.ts
@@ -89,6 +89,10 @@ export function handleIpc(cmd: string, payload?: InvokeArgs): unknown {
       return mockAllProjectsList;
     case "get_build_time":
       return "mock-dev-build";
+    case "get_platform":
+      return "macos";
+    case "get_arch":
+      return "arm64";
     case "download_update":
       return undefined;
 

--- a/src/views/ConnectView.vue
+++ b/src/views/ConnectView.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ref, computed, onMounted } from "vue";
 import Tooltip from "../components/Tooltip.vue";
+import { getOS, defaultDataDir, defaultClientDir, type OS } from "../composables/usePlatform";
 import { useConnectionStore } from "../stores/connection";
 import { useTasksStore } from "../stores/tasks";
 import { useProjectsStore } from "../stores/projects";
@@ -41,8 +42,11 @@ const RECENT_KEY = "boinc-recent-connections";
 const MAX_RECENT = 5;
 
 const mode = ref<ConnectionMode>(CONNECTION_MODE.LOCAL);
-const dataDir = ref(defaultDataDir());
-const clientDir = ref(defaultClientDir());
+// Initialise with Linux defaults so the Connect button is never blocked by
+// an empty path. onMounted overwrites these with the real platform values.
+let currentOS: OS = "linux";
+const dataDir = ref(defaultDataDir(currentOS));
+const clientDir = ref(defaultClientDir(currentOS));
 const host = ref("localhost");
 const port = ref(31416);
 const password = ref("");
@@ -50,23 +54,12 @@ const connecting = ref(false);
 const statusMessage = ref<string | null>(null);
 const recentConnections = ref<RecentConnection[]>([]);
 
-onMounted(() => {
+onMounted(async () => {
   loadRecent();
+  currentOS = await getOS();
+  dataDir.value = defaultDataDir(currentOS);
+  clientDir.value = defaultClientDir(currentOS);
 });
-
-function defaultDataDir(): string {
-  const platform = navigator.platform.toLowerCase();
-  if (platform.includes("win")) return "C:\\ProgramData\\BOINC";
-  if (platform.includes("mac")) return "/Library/Application Support/BOINC Data";
-  return "/var/lib/boinc-client";
-}
-
-function defaultClientDir(): string {
-  const platform = navigator.platform.toLowerCase();
-  if (platform.includes("win")) return "C:\\Program Files\\BOINC";
-  if (platform.includes("mac")) return "/Applications/BOINCManager.app/Contents/Resources";
-  return "/usr/bin";
-}
 
 function loadRecent() {
   try {
@@ -100,8 +93,8 @@ function removeRecent(index: number) {
 function applyRecent(entry: RecentConnection) {
   mode.value = entry.mode;
   if (entry.mode === CONNECTION_MODE.LOCAL) {
-    dataDir.value = entry.dataDir ?? defaultDataDir();
-    clientDir.value = entry.clientDir ?? defaultClientDir();
+    dataDir.value = entry.dataDir ?? defaultDataDir(currentOS);
+    clientDir.value = entry.clientDir ?? defaultClientDir(currentOS);
   } else {
     host.value = entry.host ?? "localhost";
     port.value = entry.port ?? 31416;


### PR DESCRIPTION
## Summary
- Add `get_platform()` and `get_arch()` Tauri commands backed by `cfg!(target_os)` / `cfg!(target_arch)` — compile-time constants that are immune to Rosetta 2 spoofing
- Extract `src/composables/usePlatform.ts` with `getOS()`, `getArch()`, `defaultDataDir()`, `defaultClientDir()`, `platformAssetPattern()` — single source of truth for platform-dependent logic
- Replace all 4 `navigator.platform` usages (`useUpdateCheck.ts`, `App.vue`, `ConnectView.vue` ×2) with the new composable
- Add `get_platform`/`get_arch` mocks to `handler.ts` for browser-mode dev

## Test plan
- [ ] `pnpm build` — passes with no TS errors
- [ ] `cargo clippy` — passes clean
- [ ] On macOS ARM64 (native build): check-for-updates downloads `macOS_ARM64` asset, not `macOS_x86_64`
- [ ] ConnectView shows correct default paths for the current OS immediately on open

🤖 Reviewed with Codex before submission.