### PR TITLE
fix(tests): polyfill localStorage for happy-dom v20 in test setup

### DIFF
--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -1,0 +1,30 @@
+// Test environment setup for Vitest + happy-dom.
+//
+// happy-dom v20 may not expose `localStorage` on `globalThis` as a full
+// Storage-compatible object (the `clear` method can be missing). We replace
+// it with a simple Map-backed implementation that satisfies the Storage
+// interface used by the tests.
+
+const _storage = new Map<string, string>();
+
+Object.defineProperty(globalThis, "localStorage", {
+  value: {
+    getItem: (key: string): string | null => _storage.get(key) ?? null,
+    setItem: (key: string, value: string): void => {
+      _storage.set(key, String(value));
+    },
+    removeItem: (key: string): void => {
+      _storage.delete(key);
+    },
+    clear: (): void => {
+      _storage.clear();
+    },
+    get length(): number {
+      return _storage.size;
+    },
+    key: (index: number): string | null =>
+      [..._storage.keys()][index] ?? null,
+  },
+  writable: true,
+  configurable: true,
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
   plugins: [vue()],
   test: {
     environment: "happy-dom",
+    setupFiles: ["./src/test-setup.ts"],
     include: ["src/**/*.test.ts"],
   },
 });


### PR DESCRIPTION
## Summary
- Add `src/test-setup.ts` — a Map-backed `localStorage` polyfill that provides the full `Storage` interface including `clear()`, which is missing in happy-dom v20
- Register it in `vitest.config.ts` via `setupFiles` so it runs before every test file

## Test plan
- [ ] Run `pnpm test` — all 140 tests pass (previously 13 failed with `TypeError: localStorage.clear is not a function`)

🤖 Reviewed with Codex before submission.