### PR TITLE
fix(security): sanitize project terms-of-use HTML with DOMPurify

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@tauri-apps/plugin-notification": "^2.3.3",
     "@tauri-apps/plugin-opener": "^2",
     "@tauri-apps/plugin-process": "^2.3.1",
+    "dompurify": "^3.3.1",
     "pinia": "^3.0.4",
     "vue": "^3.5.13",
     "vue-router": "^5.0.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@tauri-apps/plugin-process':
         specifier: ^2.3.1
         version: 2.3.1
+      dompurify:
+        specifier: ^3.3.1
+        version: 3.3.1
       pinia:
         specifier: ^3.0.4
         version: 3.0.4(typescript@5.6.3)(vue@3.5.28(typescript@5.6.3))
@@ -724,6 +727,9 @@ packages:
   '@types/node@25.2.3':
     resolution: {integrity: sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==}
 
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
   '@types/whatwg-mimetype@3.0.2':
     resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
 
@@ -943,6 +949,9 @@ packages:
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  dompurify@3.3.1:
+    resolution: {integrity: sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==}
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
@@ -1859,6 +1868,9 @@ snapshots:
     dependencies:
       undici-types: 7.16.0
 
+  '@types/trusted-types@2.0.7':
+    optional: true
+
   '@types/whatwg-mimetype@3.0.2': {}
 
   '@types/ws@8.18.1':
@@ -2124,6 +2136,10 @@ snapshots:
 
   detect-libc@2.1.2:
     optional: true
+
+  dompurify@3.3.1:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   eastasianwidth@0.2.0: {}
 

--- a/src/components/ProjectAttachWizard.vue
+++ b/src/components/ProjectAttachWizard.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, computed, onMounted } from "vue";
+import DOMPurify from "dompurify";
 import {
   getAllProjectsList,
   lookupAccount,
@@ -307,7 +308,7 @@ function close() {
 
         <!-- Step 3: Terms of use -->
         <div v-if="step === 3" class="wizard-body">
-          <div class="terms-box" v-if="projectConfig?.terms_of_use_is_html" v-html="projectConfig?.terms_of_use"></div>
+          <div class="terms-box" v-if="projectConfig?.terms_of_use_is_html" v-html="DOMPurify.sanitize(projectConfig.terms_of_use)"></div>
           <pre v-else class="terms-box terms-text">{{ projectConfig?.terms_of_use }}</pre>
           <label class="terms-accept">
             <input v-model="termsAccepted" type="checkbox" />


### PR DESCRIPTION
## Summary
- `ProjectAttachWizard` renders project Terms of Use via `v-html` when `terms_of_use_is_html` is true, but the HTML was passed through unsanitized
- Content comes from third-party BOINC project servers — a compromised server could inject scripts into the UI
- Wraps the value with `DOMPurify.sanitize()`, consistent with the approach used in `NoticesView` (PR #31)

> **Note:** This PR and PR #31 both add `dompurify` as a dependency. If #31 is merged first, the `package.json` change here becomes a no-op (same version). Either merge order works cleanly.

## Test plan
- [ ] Open Project Attach wizard → select a project with HTML terms of use → terms render correctly
- [ ] `pnpm lint` → 0 errors
- [ ] `pnpm test --run src/components/` → 37/37 pass

🤖 Reviewed with Codex before submission.