### PR TITLE
fix(a11y): keyboard-accessible toggles + component tests

### DIFF
--- a/src/components/PrefNumericInput.test.ts
+++ b/src/components/PrefNumericInput.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mount } from "@vue/test-utils";
+import { setActivePinia, createPinia } from "pinia";
+import PrefNumericInput from "./PrefNumericInput.vue";
+import { usePreferencesStore } from "../stores/preferences";
+import type { GlobalPreferences } from "../types/boinc";
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(),
+}));
+
+vi.mock("./PrefSourcePopover.vue", () => ({
+  default: { template: "<div />" },
+}));
+
+// max_ncpus_pct: BOINC default = 100, nonzero — good for override/file tests
+const FIELD = "max_ncpus_pct" as keyof GlobalPreferences;
+// max_bytes_sec_down: BOINC default = 0 — needed for zero-display tests
+const FIELD_ZERO_DEFAULT = "max_bytes_sec_down" as keyof GlobalPreferences;
+
+function mountNumeric(
+  modelValue: number,
+  extra: { zeroLabel?: string; field?: keyof GlobalPreferences } = {},
+) {
+  const { field = FIELD, ...rest } = extra;
+  return mount(PrefNumericInput, {
+    props: { modelValue, label: "CPU limit", field, ...rest },
+  });
+}
+
+describe("PrefNumericInput", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  it("renders the label", () => {
+    const wrapper = mountNumeric(50);
+    expect(wrapper.text()).toContain("CPU limit");
+  });
+
+  it("shows current value in the input", () => {
+    const wrapper = mountNumeric(75);
+    const input = wrapper.find("input");
+    expect(input.element.value).toBe("75");
+  });
+
+  // In PrefNumericInput, modelValue=0 means "no override" — the component falls back
+  // to store effective value or BOINC default. For fields with BOINC default=0 (e.g.
+  // max_bytes_sec_down), effectiveValue=0 and displayValue is empty string.
+  it("shows empty string when value is 0 and BOINC default is also 0", () => {
+    const wrapper = mountNumeric(0, { field: FIELD_ZERO_DEFAULT });
+    const input = wrapper.find("input");
+    expect(input.element.value).toBe("");
+  });
+
+  it("shows zeroLabel as placeholder when value is 0 and BOINC default is 0", () => {
+    const wrapper = mountNumeric(0, { field: FIELD_ZERO_DEFAULT, zeroLabel: "Unlimited" });
+    const input = wrapper.find("input");
+    expect(input.element.placeholder).toBe("Unlimited");
+  });
+
+  it("emits update:modelValue when input changes", async () => {
+    const wrapper = mountNumeric(50);
+    await wrapper.find("input").setValue("80");
+    const emitted = wrapper.emitted("update:modelValue");
+    expect(emitted).toBeTruthy();
+    expect(emitted![0][0]).toBe(80);
+  });
+
+  describe("sourceType", () => {
+    // modelValue=0 means "no override" — sourceType is 'initial'
+    it("is 'initial' when modelValue is 0 (sentinel for no override)", () => {
+      const wrapper = mountNumeric(0);
+      expect(wrapper.find(".source-dot").classes()).toContain("initial");
+    });
+
+    it("is 'override' when value differs from default and no file value", () => {
+      const wrapper = mountNumeric(50);
+      expect(wrapper.find(".source-dot").classes()).toContain("override");
+    });
+
+    it("is 'file' when value matches file preference", () => {
+      const store = usePreferencesStore();
+      store.filePrefs = { max_ncpus_pct: 50 } as GlobalPreferences;
+      const wrapper = mountNumeric(50);
+      expect(wrapper.find(".source-dot").classes()).toContain("file");
+    });
+
+    it("is 'override' when value differs from both default and file", () => {
+      const store = usePreferencesStore();
+      store.filePrefs = { max_ncpus_pct: 75 } as GlobalPreferences;
+      // value=50 differs from both file(75) and default(100)
+      const wrapper = mountNumeric(50);
+      expect(wrapper.find(".source-dot").classes()).toContain("override");
+    });
+  });
+});

--- a/src/components/PrefToggleSwitch.test.ts
+++ b/src/components/PrefToggleSwitch.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mount } from "@vue/test-utils";
+import { setActivePinia, createPinia } from "pinia";
+import PrefToggleSwitch from "./PrefToggleSwitch.vue";
+import { usePreferencesStore } from "../stores/preferences";
+import type { GlobalPreferences } from "../types/boinc";
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(),
+}));
+
+// PrefSourcePopover is a complex popover - stub it out
+vi.mock("./PrefSourcePopover.vue", () => ({
+  default: { template: "<div />" },
+}));
+
+const FIELD = "run_if_user_active" as keyof GlobalPreferences; // default: true
+
+function mountToggle(modelValue: boolean) {
+  return mount(PrefToggleSwitch, {
+    props: { modelValue, label: "Test label", field: FIELD },
+  });
+}
+
+describe("PrefToggleSwitch", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  it("renders the label", () => {
+    const wrapper = mountToggle(true);
+    expect(wrapper.text()).toContain("Test label");
+  });
+
+  it("toggle-switch has on class when modelValue is true", () => {
+    const wrapper = mountToggle(true);
+    expect(wrapper.find(".toggle-switch").classes()).toContain("on");
+  });
+
+  it("toggle-switch does not have on class when modelValue is false", () => {
+    const wrapper = mountToggle(false);
+    expect(wrapper.find(".toggle-switch").classes()).not.toContain("on");
+  });
+
+  it("emits update:modelValue with toggled value on click", async () => {
+    const wrapper = mountToggle(false);
+    await wrapper.find(".toggle-switch").trigger("click");
+    expect(wrapper.emitted("update:modelValue")).toEqual([[true]]);
+  });
+
+  it("emits update:modelValue on Enter key", async () => {
+    const wrapper = mountToggle(true);
+    await wrapper.find(".toggle-switch").trigger("keydown.enter");
+    expect(wrapper.emitted("update:modelValue")).toEqual([[false]]);
+  });
+
+  it("emits update:modelValue on Space key", async () => {
+    const wrapper = mountToggle(false);
+    await wrapper.find(".toggle-switch").trigger("keydown.space");
+    expect(wrapper.emitted("update:modelValue")).toEqual([[true]]);
+  });
+
+  it("toggle-switch has role=button and tabindex=0", () => {
+    const wrapper = mountToggle(false);
+    const toggle = wrapper.find(".toggle-switch");
+    expect(toggle.attributes("role")).toBe("button");
+    expect(toggle.attributes("tabindex")).toBe("0");
+  });
+
+  describe("sourceType", () => {
+    it("is 'initial' when value matches BOINC default and no file override", () => {
+      // run_if_user_active default is true
+      const wrapper = mountToggle(true);
+      expect(wrapper.find(".source-dot").classes()).toContain("initial");
+    });
+
+    it("is 'override' when value differs from BOINC default", () => {
+      // run_if_user_active default is true; set to false → override
+      const wrapper = mountToggle(false);
+      expect(wrapper.find(".source-dot").classes()).toContain("override");
+    });
+
+    it("is 'file' when value matches file preference value", () => {
+      const store = usePreferencesStore();
+      store.filePrefs = { run_if_user_active: false } as GlobalPreferences;
+      // value=false matches filePrefs.run_if_user_active=false → file
+      const wrapper = mountToggle(false);
+      expect(wrapper.find(".source-dot").classes()).toContain("file");
+    });
+  });
+});

--- a/src/components/PrefToggleSwitch.vue
+++ b/src/components/PrefToggleSwitch.vue
@@ -98,7 +98,11 @@ function onClearOverride() {
       <span
         class="toggle-switch"
         :class="{ on: modelValue }"
+        role="button"
+        tabindex="0"
         @click.prevent="emit('update:modelValue', !modelValue)"
+        @keydown.enter.prevent="emit('update:modelValue', !modelValue)"
+        @keydown.space.prevent="emit('update:modelValue', !modelValue)"
       >
         <span class="toggle-knob" />
       </span>

--- a/src/components/PreferencesDialog.vue
+++ b/src/components/PreferencesDialog.vue
@@ -358,7 +358,7 @@ async function save() {
                 <div v-for="(day, i) in dayNames" :key="i" class="schedule-day">
                   <div class="schedule-day-header">
                     <label class="day-toggle">
-                      <span class="toggle-switch toggle-sm" :class="{ on: dayEnabled[i] }" @click.prevent="toggleDay(i, !dayEnabled[i])">
+                      <span class="toggle-switch toggle-sm" :class="{ on: dayEnabled[i] }" role="button" tabindex="0" @click.prevent="toggleDay(i, !dayEnabled[i])" @keydown.enter.prevent="toggleDay(i, !dayEnabled[i])" @keydown.space.prevent="toggleDay(i, !dayEnabled[i])">
                         <span class="toggle-knob" />
                       </span>
                       <span class="day-name">{{ day }}</span>
@@ -425,28 +425,28 @@ async function save() {
 
               <label class="pref-row">
                 <span>Show exit confirmation</span>
-                <span class="toggle-switch" :class="{ on: managerForm.showExitConfirmation }" @click.prevent="managerForm.showExitConfirmation = !managerForm.showExitConfirmation">
+                <span class="toggle-switch" :class="{ on: managerForm.showExitConfirmation }" role="button" tabindex="0" @click.prevent="managerForm.showExitConfirmation = !managerForm.showExitConfirmation" @keydown.enter.prevent="managerForm.showExitConfirmation = !managerForm.showExitConfirmation" @keydown.space.prevent="managerForm.showExitConfirmation = !managerForm.showExitConfirmation">
                   <span class="toggle-knob" />
                 </span>
               </label>
 
               <label class="pref-row">
                 <span>Show shutdown confirmation</span>
-                <span class="toggle-switch" :class="{ on: managerForm.showShutdownConfirmation }" @click.prevent="managerForm.showShutdownConfirmation = !managerForm.showShutdownConfirmation">
+                <span class="toggle-switch" :class="{ on: managerForm.showShutdownConfirmation }" role="button" tabindex="0" @click.prevent="managerForm.showShutdownConfirmation = !managerForm.showShutdownConfirmation" @keydown.enter.prevent="managerForm.showShutdownConfirmation = !managerForm.showShutdownConfirmation" @keydown.space.prevent="managerForm.showShutdownConfirmation = !managerForm.showShutdownConfirmation">
                   <span class="toggle-knob" />
                 </span>
               </label>
 
               <label class="pref-row">
                 <span>Minimize to tray on close</span>
-                <span class="toggle-switch" :class="{ on: managerForm.minimizeToTrayOnClose }" @click.prevent="managerForm.minimizeToTrayOnClose = !managerForm.minimizeToTrayOnClose">
+                <span class="toggle-switch" :class="{ on: managerForm.minimizeToTrayOnClose }" role="button" tabindex="0" @click.prevent="managerForm.minimizeToTrayOnClose = !managerForm.minimizeToTrayOnClose" @keydown.enter.prevent="managerForm.minimizeToTrayOnClose = !managerForm.minimizeToTrayOnClose" @keydown.space.prevent="managerForm.minimizeToTrayOnClose = !managerForm.minimizeToTrayOnClose">
                   <span class="toggle-knob" />
                 </span>
               </label>
 
               <label class="pref-row">
                 <span>Start minimized to tray</span>
-                <span class="toggle-switch" :class="{ on: managerForm.startMinimizedToTray }" @click.prevent="managerForm.startMinimizedToTray = !managerForm.startMinimizedToTray">
+                <span class="toggle-switch" :class="{ on: managerForm.startMinimizedToTray }" role="button" tabindex="0" @click.prevent="managerForm.startMinimizedToTray = !managerForm.startMinimizedToTray" @keydown.enter.prevent="managerForm.startMinimizedToTray = !managerForm.startMinimizedToTray" @keydown.space.prevent="managerForm.startMinimizedToTray = !managerForm.startMinimizedToTray">
                   <span class="toggle-knob" />
                 </span>
               </label>

--- a/src/components/ProxySettingsDialog.vue
+++ b/src/components/ProxySettingsDialog.vue
@@ -79,7 +79,7 @@ async function save() {
             <div v-if="activeTab === 'http'" class="proxy-section">
               <label class="pref-row">
                 <span>Use HTTP proxy</span>
-                <span class="toggle-switch" :class="{ on: form.use_http_proxy }" @click.prevent="form.use_http_proxy = !form.use_http_proxy">
+                <span class="toggle-switch" :class="{ on: form.use_http_proxy }" role="button" tabindex="0" @click.prevent="form.use_http_proxy = !form.use_http_proxy" @keydown.enter.prevent="form.use_http_proxy = !form.use_http_proxy" @keydown.space.prevent="form.use_http_proxy = !form.use_http_proxy">
                   <span class="toggle-knob" />
                 </span>
               </label>
@@ -94,7 +94,7 @@ async function save() {
                 </label>
                 <label class="pref-row">
                   <span>Use HTTP authentication</span>
-                  <span class="toggle-switch" :class="{ on: form.use_http_auth }" @click.prevent="form.use_http_auth = !form.use_http_auth">
+                  <span class="toggle-switch" :class="{ on: form.use_http_auth }" role="button" tabindex="0" @click.prevent="form.use_http_auth = !form.use_http_auth" @keydown.enter.prevent="form.use_http_auth = !form.use_http_auth" @keydown.space.prevent="form.use_http_auth = !form.use_http_auth">
                     <span class="toggle-knob" />
                   </span>
                 </label>
@@ -115,7 +115,7 @@ async function save() {
             <div v-if="activeTab === 'socks'" class="proxy-section">
               <label class="pref-row">
                 <span>Use SOCKS proxy</span>
-                <span class="toggle-switch" :class="{ on: form.use_socks_proxy }" @click.prevent="form.use_socks_proxy = !form.use_socks_proxy">
+                <span class="toggle-switch" :class="{ on: form.use_socks_proxy }" role="button" tabindex="0" @click.prevent="form.use_socks_proxy = !form.use_socks_proxy" @keydown.enter.prevent="form.use_socks_proxy = !form.use_socks_proxy" @keydown.space.prevent="form.use_socks_proxy = !form.use_socks_proxy">
                   <span class="toggle-knob" />
                 </span>
               </label>
@@ -138,7 +138,7 @@ async function save() {
                 </label>
                 <label class="pref-row">
                   <span>Use SOCKS5 remote DNS</span>
-                  <span class="toggle-switch" :class="{ on: form.socks5_remote_dns }" @click.prevent="form.socks5_remote_dns = !form.socks5_remote_dns">
+                  <span class="toggle-switch" :class="{ on: form.socks5_remote_dns }" role="button" tabindex="0" @click.prevent="form.socks5_remote_dns = !form.socks5_remote_dns" @keydown.enter.prevent="form.socks5_remote_dns = !form.socks5_remote_dns" @keydown.space.prevent="form.socks5_remote_dns = !form.socks5_remote_dns">
                     <span class="toggle-knob" />
                   </span>
                 </label>


### PR DESCRIPTION
## Summary
- Add `role="button"`, `tabindex="0"`, `@keydown.enter`, `@keydown.space` to all 10 `<span class="toggle-switch">` elements in `PrefToggleSwitch.vue`, `ProxySettingsDialog.vue`, and `PreferencesDialog.vue` (WCAG 2.1 SC 2.1.1)
- Add 10 unit tests for `PrefToggleSwitch.vue` covering label rendering, on/off CSS class, click/enter/space emit, accessibility attributes, and `sourceType` computation
- Add 9 unit tests for `PrefNumericInput.vue` covering label rendering, value display, zero-value semantics, `zeroLabel` placeholder, emit on change, and `sourceType` computation

## Test plan
- [x] `pnpm test` — 19 new tests pass, 0 failures
- [x] `pnpm lint` — 0 warnings, 0 errors
- [ ] Manual: open Preferences dialog, verify tab navigation reaches each toggle and Enter/Space toggles it
- [ ] Manual: open Proxy Settings dialog, verify same for HTTP/SOCKS proxy toggles

🤖 Reviewed with Codex before submission.