### PR TITLE
feat(a11y): add Escape key + ARIA attributes for all 13 dialogs

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@tauri-apps/plugin-notification": "^2.3.3",
     "@tauri-apps/plugin-opener": "^2",
     "@tauri-apps/plugin-process": "^2.3.1",
+    "@vueuse/core": "^14.2.1",
     "dompurify": "^3.3.1",
     "pinia": "^3.0.4",
     "vue": "^3.5.13",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@tauri-apps/plugin-process':
         specifier: ^2.3.1
         version: 2.3.1
+      '@vueuse/core':
+        specifier: ^14.2.1
+        version: 14.2.1(vue@3.5.28(typescript@5.6.3))
       dompurify:
         specifier: ^3.3.1
         version: 3.3.1
@@ -730,6 +733,9 @@ packages:
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
+  '@types/web-bluetooth@0.0.21':
+    resolution: {integrity: sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==}
+
   '@types/whatwg-mimetype@3.0.2':
     resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
 
@@ -850,6 +856,19 @@ packages:
 
   '@vue/test-utils@2.4.6':
     resolution: {integrity: sha512-FMxEjOpYNYiFe0GkaHsnJPXFHxQ6m4t8vI/ElPGpMWxZKpmRvQ33OIrvRXemy6yha03RxhOlQuy+gZMC3CQSow==}
+
+  '@vueuse/core@14.2.1':
+    resolution: {integrity: sha512-3vwDzV+GDUNpdegRY6kzpLm4Igptq+GA0QkJ3W61Iv27YWwW/ufSlOfgQIpN6FZRMG0mkaz4gglJRtq5SeJyIQ==}
+    peerDependencies:
+      vue: ^3.5.0
+
+  '@vueuse/metadata@14.2.1':
+    resolution: {integrity: sha512-1ButlVtj5Sb/HDtIy1HFr1VqCP4G6Ypqt5MAo0lCgjokrk2mvQKsK2uuy0vqu/Ks+sHfuHo0B9Y9jn9xKdjZsw==}
+
+  '@vueuse/shared@14.2.1':
+    resolution: {integrity: sha512-shTJncjV9JTI4oVNyF1FQonetYAiTBd+Qj7cY89SWbXSkx7gyhrgtEdF2ZAVWS1S3SHlaROO6F2IesJxQEkZBw==}
+    peerDependencies:
+      vue: ^3.5.0
 
   abbrev@2.0.0:
     resolution: {integrity: sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==}
@@ -1871,6 +1890,8 @@ snapshots:
   '@types/trusted-types@2.0.7':
     optional: true
 
+  '@types/web-bluetooth@0.0.21': {}
+
   '@types/whatwg-mimetype@3.0.2': {}
 
   '@types/ws@8.18.1':
@@ -2055,6 +2076,19 @@ snapshots:
     dependencies:
       js-beautify: 1.15.4
       vue-component-type-helpers: 2.2.12
+
+  '@vueuse/core@14.2.1(vue@3.5.28(typescript@5.6.3))':
+    dependencies:
+      '@types/web-bluetooth': 0.0.21
+      '@vueuse/metadata': 14.2.1
+      '@vueuse/shared': 14.2.1(vue@3.5.28(typescript@5.6.3))
+      vue: 3.5.28(typescript@5.6.3)
+
+  '@vueuse/metadata@14.2.1': {}
+
+  '@vueuse/shared@14.2.1(vue@3.5.28(typescript@5.6.3))':
+    dependencies:
+      vue: 3.5.28(typescript@5.6.3)
 
   abbrev@2.0.0: {}
 

--- a/src/components/AboutDialog.vue
+++ b/src/components/AboutDialog.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, watch } from "vue";
+import { onKeyStroke } from "@vueuse/core";
 import { invoke } from "@tauri-apps/api/core";
 import { useUpdateCheck, startBackgroundDownload } from "../composables/useUpdateCheck";
 
@@ -19,6 +20,11 @@ const {
   checkForUpdates,
   dismissUpdate,
 } = useUpdateCheck();
+
+onKeyStroke("Escape", () => {
+  if (!props.open) return;
+  emit("close");
+});
 
 watch(
   () => props.open,
@@ -103,11 +109,11 @@ async function openGitHub() {
 <template>
   <Teleport to="body">
     <div v-if="open" class="dialog-overlay" @click.self="emit('close')">
-      <div class="about-dialog">
+      <div class="about-dialog" role="dialog" aria-modal="true" aria-labelledby="about-dialog-title">
         <div class="about-logo">
           <img src="/icon.png" alt="Fresco" width="64" height="64" />
         </div>
-        <h3>Fresco</h3>
+        <h3 id="about-dialog-title">Fresco</h3>
         <p class="build-time">Built: {{ formatBuildTime(buildTime) }}</p>
         <p class="description">
           A modern alternative to the official BOINC Manager, built with Tauri.

--- a/src/components/AccountManagerWizard.vue
+++ b/src/components/AccountManagerWizard.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, watch } from "vue";
+import { onKeyStroke } from "@vueuse/core";
 import { acctMgrInfo, acctMgrRpc, acctMgrRpcPoll } from "../composables/useRpc";
 import type { AcctMgrInfo } from "../types/boinc";
 import {
@@ -23,6 +24,11 @@ const currentMgr = ref<AcctMgrInfo | null>(null);
 const mgrUrl = ref("");
 const userName = ref("");
 const password = ref("");
+
+onKeyStroke("Escape", () => {
+  if (!props.open) return;
+  close();
+});
 
 watch(
   () => props.open,
@@ -132,9 +138,9 @@ function close() {
 <template>
   <Teleport to="body">
     <div v-if="open" class="dialog-overlay" @click.self="close">
-      <div class="wizard">
+      <div class="wizard" role="dialog" aria-modal="true" aria-labelledby="account-manager-wizard-title">
         <div class="wizard-header">
-          <h3>
+          <h3 id="account-manager-wizard-title">
             {{
               step === "form"
                 ? "Account Manager"
@@ -143,7 +149,7 @@ function close() {
                   : "Done"
             }}
           </h3>
-          <button class="close-btn" @click="close">&times;</button>
+          <button class="close-btn" aria-label="Close" @click="close">&times;</button>
         </div>
 
         <!-- Step 1: Form -->

--- a/src/components/ColumnCustomizationDialog.vue
+++ b/src/components/ColumnCustomizationDialog.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, watch } from "vue";
+import { onKeyStroke } from "@vueuse/core";
 import type { DataTableColumn } from "./DataTable.vue";
 
 const props = defineProps<{
@@ -14,6 +15,11 @@ const emit = defineEmits<{
 }>();
 
 const localKeys = ref<Set<string>>(new Set());
+
+onKeyStroke("Escape", () => {
+  if (!props.open) return;
+  emit("close");
+});
 
 watch(
   () => props.open,
@@ -46,10 +52,10 @@ function save() {
 <template>
   <Teleport to="body">
     <div v-if="open" class="dialog-overlay" @click.self="emit('close')">
-      <div class="dialog">
+      <div class="dialog" role="dialog" aria-modal="true" aria-labelledby="column-dialog-title">
         <div class="dialog-header">
-          <h3>Columns</h3>
-          <button class="close-btn" @click="emit('close')">&times;</button>
+          <h3 id="column-dialog-title">Columns</h3>
+          <button class="close-btn" aria-label="Close" @click="emit('close')">&times;</button>
         </div>
         <div class="dialog-body">
           <label

--- a/src/components/ConfirmDialog.test.ts
+++ b/src/components/ConfirmDialog.test.ts
@@ -91,4 +91,38 @@ describe("ConfirmDialog", () => {
 
     expect(wrapper.emitted("cancel")).toBeTruthy();
   });
+
+  it("emits cancel on Escape key", async () => {
+    const wrapper = mount(ConfirmDialog, {
+      props: {
+        open: false,
+        title: "Test",
+        message: "Confirm?",
+      },
+    });
+
+    await wrapper.setProps({ open: true });
+    await wrapper.vm.$nextTick();
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.emitted("cancel")).toBeTruthy();
+  });
+
+  it("has correct ARIA attributes when open", () => {
+    mount(ConfirmDialog, {
+      props: {
+        open: true,
+        title: "Delete Item",
+        message: "Are you sure?",
+      },
+    });
+    const dialog = document.body.querySelector("[role='dialog']");
+    expect(dialog).not.toBeNull();
+    expect(dialog!.getAttribute("aria-modal")).toBe("true");
+    expect(dialog!.getAttribute("aria-labelledby")).toBe("confirm-dialog-title");
+    const title = document.body.querySelector("#confirm-dialog-title");
+    expect(title).not.toBeNull();
+    expect(title!.textContent).toContain("Delete Item");
+  });
 });

--- a/src/components/ConfirmDialog.vue
+++ b/src/components/ConfirmDialog.vue
@@ -1,5 +1,7 @@
 <script setup lang="ts">
-defineProps<{
+import { onKeyStroke } from "@vueuse/core";
+
+const props = defineProps<{
   open: boolean;
   title: string;
   message: string;
@@ -10,13 +12,18 @@ const emit = defineEmits<{
   confirm: [];
   cancel: [];
 }>();
+
+onKeyStroke("Escape", () => {
+  if (!props.open) return;
+  emit("cancel");
+});
 </script>
 
 <template>
   <Teleport to="body">
     <div v-if="open" class="dialog-overlay" @click.self="emit('cancel')">
-      <div class="dialog">
-        <h3>{{ title }}</h3>
+      <div class="dialog" role="dialog" aria-modal="true" aria-labelledby="confirm-dialog-title">
+        <h3 id="confirm-dialog-title">{{ title }}</h3>
         <p>{{ message }}</p>
         <div class="dialog-actions">
           <button class="btn" @click="emit('cancel')">Cancel</button>

--- a/src/components/ExclusiveAppsDialog.vue
+++ b/src/components/ExclusiveAppsDialog.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, watch } from "vue";
+import { onKeyStroke } from "@vueuse/core";
 import { getCcConfig, setCcConfig } from "../composables/useRpc";
 import type { CcConfig } from "../types/boinc";
 
@@ -31,6 +32,11 @@ function initFromConfig(cc: CcConfig) {
     exclusive_gpu_apps: [...cc.exclusive_gpu_apps],
   };
 }
+
+onKeyStroke("Escape", () => {
+  if (!props.open) return;
+  emit("close");
+});
 
 watch(
   () => props.open,
@@ -105,10 +111,10 @@ async function save() {
 <template>
   <Teleport to="body">
     <div v-if="open" class="dialog-overlay" @click.self="emit('close')">
-      <div class="exclusive-dialog">
+      <div class="exclusive-dialog" role="dialog" aria-modal="true" aria-labelledby="exclusive-apps-dialog-title">
         <div class="exclusive-header">
-          <h3>Exclusive Applications</h3>
-          <button class="close-btn" @click="emit('close')">&times;</button>
+          <h3 id="exclusive-apps-dialog-title">Exclusive Applications</h3>
+          <button class="close-btn" aria-label="Close" @click="emit('close')">&times;</button>
         </div>
 
         <div v-if="loading" class="exclusive-loading">Loading configuration...</div>

--- a/src/components/ExitConfirmDialog.vue
+++ b/src/components/ExitConfirmDialog.vue
@@ -1,14 +1,20 @@
 <script setup lang="ts">
 import { ref } from "vue";
+import { onKeyStroke } from "@vueuse/core";
 import { useManagerSettingsStore } from "../stores/managerSettings";
 
-defineProps<{ open: boolean }>();
+const props = defineProps<{ open: boolean }>();
 const emit = defineEmits<{
   close: [];
   confirm: [shutdownClient: boolean];
 }>();
 
 const store = useManagerSettingsStore();
+
+onKeyStroke("Escape", () => {
+  if (!props.open) return;
+  emit("close");
+});
 const shutdownClient = ref(false);
 const dontAskAgain = ref(false);
 
@@ -23,8 +29,8 @@ function confirm() {
 <template>
   <Teleport to="body">
     <div v-if="open" class="dialog-overlay" @click.self="emit('close')">
-      <div class="exit-dialog">
-        <h3>Exit BOINC Manager</h3>
+      <div class="exit-dialog" role="dialog" aria-modal="true" aria-labelledby="exit-confirm-dialog-title">
+        <h3 id="exit-confirm-dialog-title">Exit BOINC Manager</h3>
         <p class="exit-message">
           Are you sure you want to exit? BOINC will continue running in the background.
         </p>

--- a/src/components/ItemPropertiesDialog.test.ts
+++ b/src/components/ItemPropertiesDialog.test.ts
@@ -147,4 +147,41 @@ describe("ItemPropertiesDialog", () => {
     const text = document.body.textContent ?? "";
     expect(text).toMatch(/Attached via account manager\s*Yes/);
   });
+
+  it("emits close on Escape key", async () => {
+    const task = makeTask();
+    const wrapper = mount(ItemPropertiesDialog, {
+      props: { open: false, type: "task", task },
+    });
+
+    await wrapper.setProps({ open: true });
+    await wrapper.vm.$nextTick();
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.emitted("close")).toBeTruthy();
+  });
+
+  it("has correct ARIA attributes when open", () => {
+    const task = makeTask();
+    mount(ItemPropertiesDialog, {
+      props: { open: true, type: "task", task },
+    });
+    const dialog = document.body.querySelector("[role='dialog']");
+    expect(dialog).not.toBeNull();
+    expect(dialog!.getAttribute("aria-modal")).toBe("true");
+    expect(dialog!.getAttribute("aria-labelledby")).toBe("item-properties-dialog-title");
+    const title = document.body.querySelector("#item-properties-dialog-title");
+    expect(title).not.toBeNull();
+  });
+
+  it("close button has aria-label", () => {
+    const task = makeTask();
+    mount(ItemPropertiesDialog, {
+      props: { open: true, type: "task", task },
+    });
+    const closeBtn = document.body.querySelector(".close-btn");
+    expect(closeBtn).not.toBeNull();
+    expect(closeBtn!.getAttribute("aria-label")).toBe("Close");
+  });
 });

--- a/src/components/ItemPropertiesDialog.vue
+++ b/src/components/ItemPropertiesDialog.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed } from "vue";
+import { onKeyStroke } from "@vueuse/core";
 import type { TaskResult, Project } from "../types/boinc";
 import { RESULT_STATE, ACTIVE_TASK_STATE, SCHEDULER_STATE } from "../types/boinc";
 
@@ -11,6 +12,11 @@ const props = defineProps<{
 }>();
 
 const emit = defineEmits<{ close: [] }>();
+
+onKeyStroke("Escape", () => {
+  if (!props.open) return;
+  emit("close");
+});
 
 // ── Formatting helpers ──────────────────────────────────────────
 
@@ -248,10 +254,10 @@ function copyAll() {
 <template>
   <Teleport to="body">
     <div v-if="open" class="dialog-overlay" @click.self="emit('close')">
-      <div class="props-dialog">
+      <div class="props-dialog" role="dialog" aria-modal="true" aria-labelledby="item-properties-dialog-title">
         <div class="props-header">
-          <h3>{{ dialogTitle }}</h3>
-          <button class="close-btn" @click="emit('close')">&times;</button>
+          <h3 id="item-properties-dialog-title">{{ dialogTitle }}</h3>
+          <button class="close-btn" aria-label="Close" @click="emit('close')">&times;</button>
         </div>
 
         <div class="props-body">

--- a/src/components/LogFlagsDialog.vue
+++ b/src/components/LogFlagsDialog.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, watch } from "vue";
+import { onKeyStroke } from "@vueuse/core";
 import { getCcConfig, setCcConfig } from "../composables/useRpc";
 import type { CcConfig, LogFlags } from "../types/boinc";
 
@@ -23,6 +24,11 @@ const flagLabels: { key: keyof LogFlags; label: string }[] = [
   { key: "state_debug", label: "State debug" },
   { key: "statefile_debug", label: "State file debug" },
 ];
+
+onKeyStroke("Escape", () => {
+  if (!props.open) return;
+  emit("close");
+});
 
 watch(
   () => props.open,
@@ -65,10 +71,10 @@ async function save() {
 <template>
   <Teleport to="body">
     <div v-if="open" class="dialog-overlay" @click.self="emit('close')">
-      <div class="logflags-dialog">
+      <div class="logflags-dialog" role="dialog" aria-modal="true" aria-labelledby="log-flags-dialog-title">
         <div class="logflags-header">
-          <h3>Diagnostic Log Flags</h3>
-          <button class="close-btn" @click="emit('close')">&times;</button>
+          <h3 id="log-flags-dialog-title">Diagnostic Log Flags</h3>
+          <button class="close-btn" aria-label="Close" @click="emit('close')">&times;</button>
         </div>
 
         <div v-if="loading" class="logflags-loading">Loading configuration...</div>

--- a/src/components/ManagerOptionsDialog.vue
+++ b/src/components/ManagerOptionsDialog.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, watch } from "vue";
+import { onKeyStroke } from "@vueuse/core";
 import { enable, disable, isEnabled } from "@tauri-apps/plugin-autostart";
 import { useManagerSettingsStore } from "../stores/managerSettings";
 
@@ -9,6 +10,11 @@ const emit = defineEmits<{ close: [] }>();
 const store = useManagerSettingsStore();
 const form = ref({ ...store.settings });
 const launchAtLogin = ref(false);
+
+onKeyStroke("Escape", () => {
+  if (!props.open) return;
+  emit("close");
+});
 
 watch(
   () => props.open,
@@ -34,10 +40,10 @@ async function save() {
 <template>
   <Teleport to="body">
     <div v-if="open" class="dialog-overlay" @click.self="emit('close')">
-      <div class="options-dialog">
+      <div class="options-dialog" role="dialog" aria-modal="true" aria-labelledby="manager-options-dialog-title">
         <div class="options-header">
-          <h3>Manager Options</h3>
-          <button class="close-btn" @click="emit('close')">&times;</button>
+          <h3 id="manager-options-dialog-title">Manager Options</h3>
+          <button class="close-btn" aria-label="Close" @click="emit('close')">&times;</button>
         </div>
 
         <div class="options-body">

--- a/src/components/PreferencesDialog.vue
+++ b/src/components/PreferencesDialog.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, computed, watch } from "vue";
+import { onKeyStroke } from "@vueuse/core";
 import { usePreferencesStore } from "../stores/preferences";
 import { useManagerSettingsStore } from "../stores/managerSettings";
 import type { GlobalPreferences } from "../types/boinc";
@@ -34,6 +35,12 @@ const hasChanges = computed(() => {
   const prefsChanged = form.value && JSON.stringify(form.value) !== originalSnapshot.value;
   const managerChanged = JSON.stringify(managerForm.value) !== JSON.stringify(managerStore.settings);
   return prefsChanged || managerChanged;
+});
+
+onKeyStroke("Escape", () => {
+  if (!props.open) return;
+  if (showProxy.value || showExclusiveApps.value) return;
+  emit("close");
 });
 
 watch(
@@ -132,10 +139,10 @@ async function save() {
 <template>
   <Teleport to="body">
     <div v-if="open" class="dialog-overlay">
-      <div class="prefs-dialog">
+      <div class="prefs-dialog" role="dialog" aria-modal="true" aria-labelledby="preferences-dialog-title">
         <div class="prefs-header">
-          <h3>Preferences</h3>
-          <button class="close-btn" @click="emit('close')">&times;</button>
+          <h3 id="preferences-dialog-title">Preferences</h3>
+          <button class="close-btn" aria-label="Close" @click="emit('close')">&times;</button>
         </div>
 
         <div v-if="store.loading && !form" class="prefs-loading">Loading preferences...</div>

--- a/src/components/ProjectAttachWizard.vue
+++ b/src/components/ProjectAttachWizard.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, computed, onMounted } from "vue";
+import { onKeyStroke } from "@vueuse/core";
 import DOMPurify from "dompurify";
 import {
   getAllProjectsList,
@@ -21,7 +22,7 @@ import {
   ATTACH_POLL_DELAY_MS,
 } from "../constants/boinc";
 
-defineProps<{ open: boolean }>();
+const props = defineProps<{ open: boolean }>();
 const emit = defineEmits<{ close: [] }>();
 
 const projects = useProjectsStore();
@@ -239,14 +240,19 @@ function close() {
   reset();
   emit("close");
 }
+
+onKeyStroke("Escape", () => {
+  if (!props.open) return;
+  close();
+});
 </script>
 
 <template>
   <Teleport to="body">
     <div v-if="open" class="dialog-overlay" @click.self="close">
-      <div class="wizard">
+      <div class="wizard" role="dialog" aria-modal="true" aria-labelledby="project-attach-wizard-title">
         <div class="wizard-header">
-          <h3>
+          <h3 id="project-attach-wizard-title">
             {{ step === 1 ? "Add Project"
              : step === 2 ? "Loading..."
              : step === 3 ? "Terms of Use"
@@ -254,7 +260,7 @@ function close() {
              : step === 5 ? "Attaching..."
              : "Done" }}
           </h3>
-          <button class="close-btn" @click="close">&times;</button>
+          <button class="close-btn" aria-label="Close" @click="close">&times;</button>
         </div>
 
         <!-- Step 1: Choose project -->

--- a/src/components/ProxySettingsDialog.vue
+++ b/src/components/ProxySettingsDialog.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, watch } from "vue";
+import { onKeyStroke } from "@vueuse/core";
 import { getProxySettings, setProxySettings } from "../composables/useRpc";
 import type { ProxyInfo } from "../types/boinc";
 
@@ -11,6 +12,11 @@ const loading = ref(false);
 const saving = ref(false);
 const error = ref("");
 const form = ref<ProxyInfo | null>(null);
+
+onKeyStroke("Escape", () => {
+  if (!props.open) return;
+  emit("close");
+});
 
 watch(
   () => props.open,
@@ -48,10 +54,10 @@ async function save() {
 <template>
   <Teleport to="body">
     <div v-if="open" class="dialog-overlay" @click.self="emit('close')">
-      <div class="proxy-dialog">
+      <div class="proxy-dialog" role="dialog" aria-modal="true" aria-labelledby="proxy-settings-dialog-title">
         <div class="proxy-header">
-          <h3>Proxy Settings</h3>
-          <button class="close-btn" @click="emit('close')">&times;</button>
+          <h3 id="proxy-settings-dialog-title">Proxy Settings</h3>
+          <button class="close-btn" aria-label="Close" @click="emit('close')">&times;</button>
         </div>
 
         <div v-if="loading" class="proxy-loading">Loading proxy settings...</div>

--- a/src/components/SelectComputerDialog.vue
+++ b/src/components/SelectComputerDialog.vue
@@ -1,9 +1,15 @@
 <script setup lang="ts">
 import { ref } from "vue";
+import { onKeyStroke } from "@vueuse/core";
 import { connect, connectLocal } from "../composables/useRpc";
 
-defineProps<{ open: boolean }>();
+const props = defineProps<{ open: boolean }>();
 const emit = defineEmits<{ close: [] }>();
+
+onKeyStroke("Escape", () => {
+  if (!props.open) return;
+  emit("close");
+});
 
 const hostname = ref("localhost");
 const port = ref(31416);
@@ -41,10 +47,10 @@ async function doConnectLocal() {
 <template>
   <Teleport to="body">
     <div v-if="open" class="dialog-overlay" @click.self="emit('close')">
-      <div class="dialog">
+      <div class="dialog" role="dialog" aria-modal="true" aria-labelledby="select-computer-dialog-title">
         <div class="dialog-header">
-          <h3>Select Computer</h3>
-          <button class="close-btn" @click="emit('close')">&times;</button>
+          <h3 id="select-computer-dialog-title">Select Computer</h3>
+          <button class="close-btn" aria-label="Close" @click="emit('close')">&times;</button>
         </div>
 
         <div class="dialog-body">


### PR DESCRIPTION
## Summary
- All 13 modal dialogs now close on Escape key press (WCAG 2.1 SC 2.1.1)
- Added `role="dialog"`, `aria-modal="true"`, and `aria-labelledby` to every dialog container
- Added `aria-label="Close"` to all × close buttons for screen readers
- PreferencesDialog guards Escape when child dialogs (ProxySettings, ExclusiveApps) are open
- ConfirmDialog correctly emits `cancel` (not `close`) on Escape
- Extended tests for ConfirmDialog and ItemPropertiesDialog with Escape key and ARIA assertions

## Test plan
- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm test --run` — all dialog-related tests pass (ConfirmDialog 8/8, ItemPropertiesDialog 10/10)
- [ ] Open each dialog → press Escape → dialog closes
- [ ] Open Preferences → Proxy Settings → Escape closes only Proxy → Escape again closes Preferences
- [ ] Screen reader (VoiceOver) announces dialog role and title when opened

🤖 Reviewed with Codex before submission.