### PR TITLE
feat(a11y): add ARIA roles and keyboard navigation to ContextMenu

### DIFF
--- a/src/components/ContextMenu.test.ts
+++ b/src/components/ContextMenu.test.ts
@@ -2,6 +2,25 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { mount } from "@vue/test-utils";
 import ContextMenu from "./ContextMenu.vue";
 
+const baseItems = [
+  { label: "Edit", action: "edit" },
+  { label: "Delete", action: "delete", danger: true },
+];
+
+function mountMenu(
+  propsOverride?: Record<string, unknown>,
+) {
+  return mount(ContextMenu, {
+    props: {
+      open: true,
+      x: 100,
+      y: 200,
+      items: baseItems,
+      ...propsOverride,
+    },
+  });
+}
+
 describe("ContextMenu", () => {
   beforeEach(() => {
     document.body.innerHTML = "";
@@ -20,17 +39,7 @@ describe("ContextMenu", () => {
   });
 
   it("renders items when open", () => {
-    mount(ContextMenu, {
-      props: {
-        open: true,
-        x: 100,
-        y: 200,
-        items: [
-          { label: "Edit", action: "edit" },
-          { label: "Delete", action: "delete", danger: true },
-        ],
-      },
-    });
+    mountMenu();
     const menu = document.body.querySelector(".context-menu");
     expect(menu).not.toBeNull();
     expect(menu!.textContent).toContain("Edit");
@@ -38,58 +47,230 @@ describe("ContextMenu", () => {
   });
 
   it("renders dividers", () => {
-    mount(ContextMenu, {
-      props: {
-        open: true,
-        x: 0,
-        y: 0,
-        items: [
-          { label: "A", action: "a" },
-          { label: "", action: "", divider: true },
-          { label: "B", action: "b" },
-        ],
-      },
+    mountMenu({
+      items: [
+        { label: "A", action: "a" },
+        { label: "", action: "", divider: true },
+        { label: "B", action: "b" },
+      ],
     });
-    // Dividers are rendered as div elements (not buttons) between the button items
     const menu = document.body.querySelector(".context-menu");
     expect(menu).not.toBeNull();
     const buttons = menu!.querySelectorAll("button");
-    expect(buttons.length).toBe(2); // A and B, divider is a div
-    const divs = menu!.querySelectorAll("div");
-    // There should be divider divs (at least the context-divider one)
-    expect(divs.length).toBeGreaterThanOrEqual(1);
+    expect(buttons.length).toBe(2);
+    const dividers = menu!.querySelectorAll("[role='separator']");
+    expect(dividers.length).toBe(1);
   });
 
   it("emits action on click", async () => {
-    const wrapper = mount(ContextMenu, {
-      props: {
-        open: true,
-        x: 0,
-        y: 0,
-        items: [{ label: "Do It", action: "do-it" }],
-      },
-    });
+    const wrapper = mountMenu();
     const button = document.body.querySelector("button") as HTMLElement;
     expect(button).not.toBeNull();
     button.click();
     await wrapper.vm.$nextTick();
     expect(wrapper.emitted("action")).toBeTruthy();
-    expect(wrapper.emitted("action")![0]).toEqual(["do-it"]);
+    expect(wrapper.emitted("action")![0]).toEqual(["edit"]);
   });
 
   it("does not emit action for disabled items", async () => {
-    const wrapper = mount(ContextMenu, {
-      props: {
-        open: true,
-        x: 0,
-        y: 0,
-        items: [{ label: "Disabled", action: "nope", disabled: true }],
-      },
+    const wrapper = mountMenu({
+      items: [{ label: "Disabled", action: "nope", disabled: true }],
     });
     const button = document.body.querySelector("button") as HTMLElement;
     expect(button).not.toBeNull();
     button.click();
     await wrapper.vm.$nextTick();
     expect(wrapper.emitted("action")).toBeFalsy();
+  });
+
+  // --- ARIA attributes ---
+
+  it("has role='menu' on container", () => {
+    mountMenu();
+    const menu = document.body.querySelector("[role='menu']");
+    expect(menu).not.toBeNull();
+  });
+
+  it("has role='menuitem' on each button", () => {
+    mountMenu();
+    const items = document.body.querySelectorAll("[role='menuitem']");
+    expect(items.length).toBe(2);
+  });
+
+  it("has role='separator' on dividers", () => {
+    mountMenu({
+      items: [
+        { label: "A", action: "a" },
+        { label: "", action: "", divider: true },
+        { label: "B", action: "b" },
+      ],
+    });
+    const separators = document.body.querySelectorAll("[role='separator']");
+    expect(separators.length).toBe(1);
+  });
+
+  it("sets aria-disabled on disabled items", () => {
+    mountMenu({
+      items: [
+        { label: "Ok", action: "ok" },
+        { label: "Nope", action: "nope", disabled: true },
+      ],
+    });
+    const items = document.body.querySelectorAll("[role='menuitem']");
+    expect(items[0].getAttribute("aria-disabled")).toBeNull();
+    expect(items[1].getAttribute("aria-disabled")).toBe("true");
+  });
+
+  // --- Keyboard navigation ---
+
+  it("focuses first enabled item on open", async () => {
+    const wrapper = mount(ContextMenu, {
+      props: { open: false, x: 0, y: 0, items: baseItems },
+    });
+    await wrapper.setProps({ open: true });
+    await wrapper.vm.$nextTick();
+    await wrapper.vm.$nextTick();
+
+    const items = document.body.querySelectorAll("[role='menuitem']");
+    expect(document.activeElement).toBe(items[0]);
+  });
+
+  it("skips disabled items when focusing on open", async () => {
+    const wrapper = mount(ContextMenu, {
+      props: {
+        open: false,
+        x: 0,
+        y: 0,
+        items: [
+          { label: "Disabled", action: "d", disabled: true },
+          { label: "Enabled", action: "e" },
+        ],
+      },
+    });
+    await wrapper.setProps({ open: true });
+    await wrapper.vm.$nextTick();
+    await wrapper.vm.$nextTick();
+
+    const items = document.body.querySelectorAll("[role='menuitem']");
+    expect(document.activeElement).toBe(items[1]);
+  });
+
+  it("ArrowDown moves focus to next enabled item", async () => {
+    const wrapper = mount(ContextMenu, {
+      props: { open: false, x: 0, y: 0, items: baseItems },
+    });
+    await wrapper.setProps({ open: true });
+    await wrapper.vm.$nextTick();
+    await wrapper.vm.$nextTick();
+
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown" }));
+    await wrapper.vm.$nextTick();
+
+    const items = document.body.querySelectorAll("[role='menuitem']");
+    expect(document.activeElement).toBe(items[1]);
+  });
+
+  it("ArrowDown wraps from last to first", async () => {
+    const wrapper = mount(ContextMenu, {
+      props: { open: false, x: 0, y: 0, items: baseItems },
+    });
+    await wrapper.setProps({ open: true });
+    await wrapper.vm.$nextTick();
+    await wrapper.vm.$nextTick();
+
+    // Focus is on first item; ArrowDown twice wraps to first
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown" }));
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown" }));
+    await wrapper.vm.$nextTick();
+
+    const items = document.body.querySelectorAll("[role='menuitem']");
+    expect(document.activeElement).toBe(items[0]);
+  });
+
+  it("ArrowUp moves focus to previous enabled item", async () => {
+    const wrapper = mount(ContextMenu, {
+      props: { open: false, x: 0, y: 0, items: baseItems },
+    });
+    await wrapper.setProps({ open: true });
+    await wrapper.vm.$nextTick();
+    await wrapper.vm.$nextTick();
+
+    // Focus starts on first; ArrowUp wraps to last
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowUp" }));
+    await wrapper.vm.$nextTick();
+
+    const items = document.body.querySelectorAll("[role='menuitem']");
+    expect(document.activeElement).toBe(items[1]);
+  });
+
+  it("Home moves focus to first enabled item", async () => {
+    const wrapper = mount(ContextMenu, {
+      props: { open: false, x: 0, y: 0, items: baseItems },
+    });
+    await wrapper.setProps({ open: true });
+    await wrapper.vm.$nextTick();
+    await wrapper.vm.$nextTick();
+
+    // Move to second, then Home
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown" }));
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Home" }));
+    await wrapper.vm.$nextTick();
+
+    const items = document.body.querySelectorAll("[role='menuitem']");
+    expect(document.activeElement).toBe(items[0]);
+  });
+
+  it("End moves focus to last enabled item", async () => {
+    const wrapper = mount(ContextMenu, {
+      props: { open: false, x: 0, y: 0, items: baseItems },
+    });
+    await wrapper.setProps({ open: true });
+    await wrapper.vm.$nextTick();
+    await wrapper.vm.$nextTick();
+
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "End" }));
+    await wrapper.vm.$nextTick();
+
+    const items = document.body.querySelectorAll("[role='menuitem']");
+    expect(document.activeElement).toBe(items[1]);
+  });
+
+  it("Escape emits close", async () => {
+    const wrapper = mount(ContextMenu, {
+      props: { open: false, x: 0, y: 0, items: baseItems },
+    });
+    await wrapper.setProps({ open: true });
+    await wrapper.vm.$nextTick();
+    await wrapper.vm.$nextTick();
+
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.emitted("close")).toBeTruthy();
+  });
+
+  it("ArrowDown skips disabled items", async () => {
+    const wrapper = mount(ContextMenu, {
+      props: {
+        open: false,
+        x: 0,
+        y: 0,
+        items: [
+          { label: "First", action: "first" },
+          { label: "Disabled", action: "disabled", disabled: true },
+          { label: "Third", action: "third" },
+        ],
+      },
+    });
+    await wrapper.setProps({ open: true });
+    await wrapper.vm.$nextTick();
+    await wrapper.vm.$nextTick();
+
+    // Focus is on "First"; ArrowDown should skip "Disabled" and land on "Third"
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown" }));
+    await wrapper.vm.$nextTick();
+
+    const items = document.body.querySelectorAll("[role='menuitem']");
+    expect(document.activeElement).toBe(items[2]);
   });
 });

--- a/src/components/ContextMenu.vue
+++ b/src/components/ContextMenu.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, watch, onMounted, onUnmounted } from "vue";
+import { ref, computed, watch, nextTick, onMounted, onUnmounted } from "vue";
 
 export interface ContextMenuItem {
   label: string;
@@ -22,6 +22,62 @@ const emit = defineEmits<{
 }>();
 
 const menuRef = ref<HTMLElement | null>(null);
+const focusedIndex = ref(-1);
+
+// Indices of non-divider items within props.items
+const actionableIndices = computed(() =>
+  props.items.reduce<number[]>((acc, item, i) => {
+    if (!item.divider) acc.push(i);
+    return acc;
+  }, []),
+);
+
+const enabledIndices = computed(() =>
+  actionableIndices.value.filter((i) => !props.items[i].disabled),
+);
+
+function getMenuItemButtons(): HTMLElement[] {
+  if (!menuRef.value) return [];
+  return Array.from(menuRef.value.querySelectorAll<HTMLElement>("[role='menuitem']"));
+}
+
+function focusActionableAt(actionablePos: number) {
+  focusedIndex.value = actionablePos;
+  const buttons = getMenuItemButtons();
+  buttons[actionablePos]?.focus();
+}
+
+function findActionablePos(itemIndex: number): number {
+  return actionableIndices.value.indexOf(itemIndex);
+}
+
+function focusFirstEnabled() {
+  const firstIdx = enabledIndices.value[0];
+  if (firstIdx !== undefined) {
+    focusActionableAt(findActionablePos(firstIdx));
+  }
+}
+
+function focusLastEnabled() {
+  const lastIdx = enabledIndices.value[enabledIndices.value.length - 1];
+  if (lastIdx !== undefined) {
+    focusActionableAt(findActionablePos(lastIdx));
+  }
+}
+
+function focusNextEnabled() {
+  const currentItemIdx = actionableIndices.value[focusedIndex.value];
+  const currentEnabledPos = enabledIndices.value.indexOf(currentItemIdx);
+  const nextPos = (currentEnabledPos + 1) % enabledIndices.value.length;
+  focusActionableAt(findActionablePos(enabledIndices.value[nextPos]));
+}
+
+function focusPrevEnabled() {
+  const currentItemIdx = actionableIndices.value[focusedIndex.value];
+  const currentEnabledPos = enabledIndices.value.indexOf(currentItemIdx);
+  const prevPos = (currentEnabledPos - 1 + enabledIndices.value.length) % enabledIndices.value.length;
+  focusActionableAt(findActionablePos(enabledIndices.value[prevPos]));
+}
 
 function handleClickOutside(e: MouseEvent) {
   if (menuRef.value && !menuRef.value.contains(e.target as Node)) {
@@ -30,8 +86,34 @@ function handleClickOutside(e: MouseEvent) {
 }
 
 function handleKeydown(e: KeyboardEvent) {
-  if (e.key === "Escape") {
-    emit("close");
+  switch (e.key) {
+    case "Escape":
+      emit("close");
+      break;
+    case "ArrowDown":
+      e.preventDefault();
+      if (focusedIndex.value < 0) {
+        focusFirstEnabled();
+      } else {
+        focusNextEnabled();
+      }
+      break;
+    case "ArrowUp":
+      e.preventDefault();
+      if (focusedIndex.value < 0) {
+        focusLastEnabled();
+      } else {
+        focusPrevEnabled();
+      }
+      break;
+    case "Home":
+      e.preventDefault();
+      focusFirstEnabled();
+      break;
+    case "End":
+      e.preventDefault();
+      focusLastEnabled();
+      break;
   }
 }
 
@@ -41,14 +123,23 @@ function handleAction(item: ContextMenuItem) {
   emit("close");
 }
 
+function getTabIndex(itemIndex: number): number {
+  const actionablePos = findActionablePos(itemIndex);
+  return actionablePos === focusedIndex.value ? 0 : -1;
+}
+
 watch(
   () => props.open,
-  (isOpen) => {
+  async (isOpen) => {
     if (isOpen) {
+      focusedIndex.value = -1;
+      document.addEventListener("keydown", handleKeydown);
+      // Delay click listener to avoid the opening click from immediately closing
       setTimeout(() => {
         document.addEventListener("click", handleClickOutside);
-        document.addEventListener("keydown", handleKeydown);
       }, 0);
+      await nextTick();
+      focusFirstEnabled();
     } else {
       document.removeEventListener("click", handleClickOutside);
       document.removeEventListener("keydown", handleKeydown);
@@ -58,8 +149,8 @@ watch(
 
 onMounted(() => {
   if (props.open) {
-    document.addEventListener("click", handleClickOutside);
     document.addEventListener("keydown", handleKeydown);
+    document.addEventListener("click", handleClickOutside);
   }
 });
 
@@ -74,16 +165,20 @@ onUnmounted(() => {
     <div
       v-if="open"
       ref="menuRef"
+      role="menu"
       class="context-menu"
       :style="{ left: `${x}px`, top: `${y}px` }"
     >
       <template v-for="(item, idx) in items" :key="idx">
-        <div v-if="item.divider" class="context-divider" />
+        <div v-if="item.divider" role="separator" class="context-divider" />
         <button
           v-else
+          role="menuitem"
           class="context-item"
           :class="{ danger: item.danger, disabled: item.disabled }"
-          :disabled="item.disabled"
+          :disabled="item.disabled || undefined"
+          :aria-disabled="item.disabled || undefined"
+          :tabindex="getTabIndex(idx)"
           @click="handleAction(item)"
         >
           {{ item.label }}
@@ -118,16 +213,19 @@ onUnmounted(() => {
   transition: background var(--transition-fast);
 }
 
-.context-item:hover:not(.disabled) {
+.context-item:hover:not(.disabled),
+.context-item:focus:not(.disabled) {
   background: var(--color-accent-light);
   color: var(--color-accent);
+  outline: none;
 }
 
 .context-item.danger {
   color: var(--color-danger);
 }
 
-.context-item.danger:hover:not(.disabled) {
+.context-item.danger:hover:not(.disabled),
+.context-item.danger:focus:not(.disabled) {
   background: var(--color-danger-light);
   color: var(--color-danger);
 }


### PR DESCRIPTION
## Summary
- Add `role="menu"`, `role="menuitem"`, `role="separator"` to ContextMenu component
- Implement ArrowDown/ArrowUp keyboard navigation with wrap-around, skipping disabled items
- Add Home/End keys to jump to first/last enabled item
- Auto-focus first enabled item when menu opens
- Add `aria-disabled` on disabled items and `:focus` styles for keyboard visibility
- Extend tests from 5 to 18 covering ARIA attributes, arrow navigation, wrapping, and disabled skipping

Closes #36

## Test plan
- [ ] `pnpm lint` passes with 0 errors
- [ ] `pnpm test --run` — ContextMenu 18/18 tests pass
- [ ] Right-click task/project/transfer row → menu appears, first enabled item focused
- [ ] ArrowDown/ArrowUp navigates between enabled items, skips disabled
- [ ] Home/End jumps to first/last enabled item
- [ ] Escape closes menu
- [ ] VoiceOver announces menu role and menuitem names

🤖 Reviewed with Codex before submission.