### PR TITLE
feat: show app version in About dialog and fix macOS bundle version

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -68,6 +68,7 @@
       "icons/icon.ico"
     ],
     "macOS": {
+      "bundleVersion": "1",
       "dmg": {
         "background": "icons/dmg-background.png",
         "windowSize": {

--- a/src/components/AboutDialog.vue
+++ b/src/components/AboutDialog.vue
@@ -11,6 +11,7 @@ const emit = defineEmits<{ close: [] }>();
 const { t } = useI18n();
 const updating = ref(false);
 const updateError = ref("");
+const appVersion = ref("");
 const {
   buildTime,
   updateAvailable,
@@ -22,6 +23,10 @@ const {
   checkForUpdates,
   dismissUpdate,
 } = useUpdateCheck();
+
+import("@tauri-apps/api/app").then(({ getVersion }) => getVersion()).then((v) => {
+  appVersion.value = v;
+}).catch(() => {});
 
 onKeyStroke("Escape", () => {
   if (!props.open) return;
@@ -116,6 +121,7 @@ async function openGitHub() {
           <img src="/icon.png" alt="Fresco" width="64" height="64" />
         </div>
         <h3 id="about-dialog-title">{{ $t('about.title') }}</h3>
+        <p v-if="appVersion" class="app-version">v{{ appVersion }}</p>
         <p class="build-time">{{ $t('about.built', { time: formatBuildTime(buildTime) }) }}</p>
         <p class="description">
           {{ $t('about.description') }}
@@ -198,6 +204,13 @@ async function openGitHub() {
   margin: 0 0 4px;
   font-size: var(--font-size-xl);
   font-weight: 600;
+}
+
+.app-version {
+  font-size: var(--font-size-md);
+  font-weight: 500;
+  color: var(--color-text-secondary);
+  margin: 0 0 2px;
 }
 
 .build-time {


### PR DESCRIPTION
## Summary
- Display app version (`v0.1.0`) in the in-app About dialog using `getVersion()` from `@tauri-apps/api/app`; hidden gracefully when unavailable (dev/mock mode)
- Set `bundle.macOS.bundleVersion: "1"` in `tauri.conf.json` so the macOS system About dialog shows `Version 0.1.0 (1)` instead of the redundant `Version 0.1.0 (0.1.0)`

## Test plan
- [ ] Open About dialog (⚙ → About) — confirm `v0.1.0` appears between the title and "Built:" line
- [ ] Open macOS system About (`Fresco > About Fresco` menu) on a release build — confirm `Version 0.1.0 (1)`
- [ ] Open About dialog in browser dev mode (mock IPC) — confirm version line is hidden, no errors

🤖 Reviewed with Codex before submission.