### PR TITLE
fix: decouple statusVariant from translated strings

### DIFF
--- a/src/views/ProjectsView.vue
+++ b/src/views/ProjectsView.vue
@@ -74,17 +74,10 @@ function projectStatus(project: Project): string {
   return t("projects.status.active");
 }
 
-function statusVariant(status: string): "default" | "success" | "warning" | "danger" | "info" {
-  switch (status) {
-    case "Active":
-      return "success";
-    case "Suspended":
-      return "warning";
-    case "No new tasks":
-      return "info";
-    default:
-      return "default";
-  }
+function statusVariant(project: Project): "default" | "success" | "warning" | "danger" | "info" {
+  if (project.suspended_via_gui) return "warning";
+  if (project.dont_request_more_work) return "info";
+  return "success";
 }
 
 function getSortValue(project: Project, key: string): number | string {
@@ -442,7 +435,7 @@ function isColVisible(key: string): boolean {
             <td v-if="isColVisible('totalCredit')" class="col-number">{{ formatCredit(project.user_total_credit) }}</td>
             <td v-if="isColVisible('avgCredit')" class="col-number">{{ formatCredit(project.user_expavg_credit) }}</td>
             <td v-if="isColVisible('status')">
-              <StatusBadge :variant="statusVariant(projectStatus(project))">
+              <StatusBadge :variant="statusVariant(project)">
                 {{ projectStatus(project) }}
               </StatusBadge>
             </td>

--- a/src/views/TasksView.vue
+++ b/src/views/TasksView.vue
@@ -116,25 +116,18 @@ function taskStatus(task: {
   return t("tasks.status.waiting");
 }
 
-function statusVariant(status: string): "default" | "success" | "warning" | "danger" | "info" {
-  switch (status) {
-    case "Running":
-      return "success";
-    case "Waiting to run":
-    case "Waiting":
-    case "Downloading":
-    case "Uploading":
-      return "info";
-    case "Suspended":
-      return "warning";
-    case "Computation error":
-    case "Aborted":
-      return "danger";
-    case "Ready to report":
-      return "default";
-    default:
-      return "default";
+function statusVariant(task: TaskResult): "default" | "success" | "warning" | "danger" | "info" {
+  if (task.ready_to_report) return "default";
+  if (task.suspended_via_gui) return "warning";
+  if (task.state === RESULT_STATE.FILES_DOWNLOADING || task.state === RESULT_STATE.FILES_UPLOADING) return "info";
+  if (task.state === RESULT_STATE.COMPUTE_ERROR || task.state === RESULT_STATE.ABORTED) return "danger";
+  if (task.active_task) {
+    if (task.active_task_state === ACTIVE_TASK_STATE.EXECUTING) {
+      return task.scheduler_state === SCHEDULER_STATE.SCHEDULED ? "success" : "info";
+    }
+    if (task.active_task_state === ACTIVE_TASK_STATE.SUSPENDED) return "warning";
   }
+  return "default";
 }
 
 function getSortValue(task: TaskResult, key: string): number | string {
@@ -488,7 +481,7 @@ function isColVisible(key: string): boolean {
           {{ formatTime(task.estimated_cpu_time_remaining) }}
         </td>
         <td v-if="isColVisible('status')">
-          <StatusBadge :variant="statusVariant(taskStatus(task))">
+          <StatusBadge :variant="statusVariant(task)">
             {{ taskStatus(task) }}
           </StatusBadge>
         </td>


### PR DESCRIPTION
## Summary
- `statusVariant` in `ProjectsView` and `TasksView` was comparing against hardcoded English strings (`"Active"`, `"Running"`, `"Suspended"`, …), but received already-translated values from `projectStatus()`/`taskStatus()` — causing badge variants to fall through to `default` in all non-English locales
- Fixed by changing `statusVariant` to accept the raw `Project`/`TaskResult` object and derive the variant directly from data fields, mirroring the same logic as `projectStatus`/`taskStatus` but independent of locale

## Test plan
- [ ] Switch app language to any non-English locale (e.g. German or Russian)
- [ ] Open Projects view — confirm active projects show green badge, suspended show yellow, no-new-tasks show blue
- [ ] Open Tasks view — confirm Running = green, Suspended = yellow, errors = red, downloading/uploading/waiting = blue

🤖 Reviewed with Codex before submission.