### PR TITLE
test: add tests for 6 uncovered stores

### DIFF
--- a/src/stores/diskUsage.test.ts
+++ b/src/stores/diskUsage.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { setActivePinia, createPinia } from "pinia";
+import { useDiskUsageStore } from "./diskUsage";
+import type { DiskUsage } from "../types/boinc";
+
+vi.mock("../composables/useRpc", () => ({
+  getDiskUsage: vi.fn(),
+}));
+
+import { getDiskUsage } from "../composables/useRpc";
+
+const mockGetDiskUsage = vi.mocked(getDiskUsage);
+
+const sampleUsage: DiskUsage = {
+  projects: [{ master_url: "https://example.com/", disk_usage: 5000000 }],
+  d_total: 500000000000,
+  d_free: 200000000000,
+  d_boinc: 5000000,
+  d_allowed: 100000000000,
+};
+
+describe("useDiskUsageStore", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("starts with empty usage", () => {
+    const store = useDiskUsageStore();
+    expect(store.usage.d_total).toBe(0);
+    expect(store.loading).toBe(false);
+    expect(store.error).toBeNull();
+  });
+
+  it("fetchDiskUsage populates data", async () => {
+    mockGetDiskUsage.mockResolvedValueOnce(sampleUsage);
+    const store = useDiskUsageStore();
+    await store.fetchDiskUsage();
+    expect(store.usage).toEqual(sampleUsage);
+    expect(store.loading).toBe(false);
+  });
+
+  it("fetchDiskUsage sets error on failure", async () => {
+    mockGetDiskUsage.mockRejectedValueOnce(new Error("Network error"));
+    const store = useDiskUsageStore();
+    await store.fetchDiskUsage();
+    expect(store.error).toBe("Error: Network error");
+    expect(store.loading).toBe(false);
+  });
+
+  it("polls and stops", async () => {
+    mockGetDiskUsage.mockResolvedValue(sampleUsage);
+    const store = useDiskUsageStore();
+    store.startPolling(1000);
+
+    await vi.advanceTimersByTimeAsync(100);
+    const initialCalls = mockGetDiskUsage.mock.calls.length;
+    expect(initialCalls).toBeGreaterThanOrEqual(1);
+
+    store.stopPolling();
+    const afterStop = mockGetDiskUsage.mock.calls.length;
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(mockGetDiskUsage.mock.calls.length).toBe(afterStop);
+  });
+});

--- a/src/stores/managerSettings.test.ts
+++ b/src/stores/managerSettings.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { setActivePinia, createPinia } from "pinia";
+
+vi.mock("@tauri-apps/api/window", () => ({
+  getCurrentWindow: () => ({
+    setTheme: vi.fn(),
+  }),
+}));
+
+import { useManagerSettingsStore } from "./managerSettings";
+
+const STORAGE_KEY = "boinc-manager-settings";
+
+describe("useManagerSettingsStore", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it("loads defaults when localStorage is empty", () => {
+    const store = useManagerSettingsStore();
+    expect(store.settings.language).toBe("auto");
+    expect(store.settings.theme).toBe("system");
+    expect(store.settings.showExitConfirmation).toBe(true);
+    expect(store.settings.checkForUpdates).toBe(true);
+  });
+
+  it("loads saved settings from localStorage", () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ language: "ru", theme: "dark" }));
+    const store = useManagerSettingsStore();
+    expect(store.settings.language).toBe("ru");
+    expect(store.settings.theme).toBe("dark");
+    // Defaults are preserved for unset keys
+    expect(store.settings.showExitConfirmation).toBe(true);
+  });
+
+  it("handles corrupt localStorage gracefully", () => {
+    localStorage.setItem(STORAGE_KEY, "not-json{{{");
+    const store = useManagerSettingsStore();
+    expect(store.settings.language).toBe("auto");
+  });
+
+  it("resetSettings restores defaults", () => {
+    const store = useManagerSettingsStore();
+    store.settings.language = "de";
+    store.settings.theme = "dark";
+    store.resetSettings();
+    expect(store.settings.language).toBe("auto");
+    expect(store.settings.theme).toBe("system");
+  });
+
+  it("applies 'light' theme to documentElement", () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ theme: "light" }));
+    useManagerSettingsStore();
+    expect(document.documentElement.dataset.theme).toBe("light");
+  });
+
+  it("removes dataset.theme for 'system' theme", () => {
+    document.documentElement.dataset.theme = "dark";
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ theme: "system" }));
+    useManagerSettingsStore();
+    expect(document.documentElement.dataset.theme).toBeUndefined();
+  });
+});

--- a/src/stores/notices.test.ts
+++ b/src/stores/notices.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { setActivePinia, createPinia } from "pinia";
+import { useNoticesStore } from "./notices";
+import type { Notice } from "../types/boinc";
+
+vi.mock("../composables/useRpc", () => ({
+  getNotices: vi.fn(),
+}));
+
+vi.mock("../composables/useNotifications", () => ({
+  notifyNewNotices: vi.fn(),
+}));
+
+import { getNotices } from "../composables/useRpc";
+import { notifyNewNotices } from "../composables/useNotifications";
+
+const mockGetNotices = vi.mocked(getNotices);
+const mockNotify = vi.mocked(notifyNewNotices);
+
+function makeNotice(seqno: number, overrides: Partial<Notice> = {}): Notice {
+  return {
+    seqno,
+    title: `Notice ${seqno}`,
+    description: "A notice",
+    create_time: 1700000000 + seqno,
+    category: "client",
+    link: "",
+    project_name: "",
+    is_private: false,
+    ...overrides,
+  };
+}
+
+describe("useNoticesStore", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("starts with empty notices", () => {
+    const store = useNoticesStore();
+    expect(store.notices).toEqual([]);
+    expect(store.loading).toBe(false);
+    expect(store.error).toBeNull();
+  });
+
+  it("fetchNotices appends new notices and updates lastSeqno", async () => {
+    const notices = [makeNotice(1), makeNotice(2)];
+    mockGetNotices.mockResolvedValueOnce(notices);
+
+    const store = useNoticesStore();
+    await store.fetchNotices();
+
+    expect(store.notices).toEqual(notices);
+    expect(mockGetNotices).toHaveBeenCalledWith(0);
+    expect(mockNotify).toHaveBeenCalledWith(2);
+  });
+
+  it("fetchNotices accumulates across calls", async () => {
+    mockGetNotices.mockResolvedValueOnce([makeNotice(1)]);
+    const store = useNoticesStore();
+    await store.fetchNotices();
+
+    mockGetNotices.mockResolvedValueOnce([makeNotice(2), makeNotice(3)]);
+    await store.fetchNotices();
+
+    expect(store.notices).toHaveLength(3);
+    expect(mockGetNotices).toHaveBeenLastCalledWith(1);
+  });
+
+  it("fetchNotices does not notify when no new notices", async () => {
+    mockGetNotices.mockResolvedValueOnce([]);
+    const store = useNoticesStore();
+    await store.fetchNotices();
+
+    expect(store.notices).toEqual([]);
+    expect(mockNotify).not.toHaveBeenCalled();
+  });
+
+  it("fetchNotices sets error on failure", async () => {
+    mockGetNotices.mockRejectedValueOnce(new Error("Connection lost"));
+    const store = useNoticesStore();
+    await store.fetchNotices();
+
+    expect(store.error).toBe("Error: Connection lost");
+    expect(store.loading).toBe(false);
+  });
+
+  it("polls and stops", async () => {
+    mockGetNotices.mockResolvedValue([]);
+    const store = useNoticesStore();
+    store.startPolling(1000);
+
+    await vi.advanceTimersByTimeAsync(100);
+    const initialCalls = mockGetNotices.mock.calls.length;
+    expect(initialCalls).toBeGreaterThanOrEqual(1);
+
+    store.stopPolling();
+    const afterStop = mockGetNotices.mock.calls.length;
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(mockGetNotices.mock.calls.length).toBe(afterStop);
+  });
+});

--- a/src/stores/preferences.test.ts
+++ b/src/stores/preferences.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { setActivePinia, createPinia } from "pinia";
+import { usePreferencesStore } from "./preferences";
+import type { GlobalPreferences } from "../types/boinc";
+
+vi.mock("../composables/useRpc", () => ({
+  getPreferences: vi.fn(),
+  setPreferences: vi.fn(),
+  getGlobalPrefsWorking: vi.fn(),
+  getGlobalPrefsFile: vi.fn(),
+}));
+
+import {
+  getPreferences,
+  setPreferences,
+  getGlobalPrefsWorking,
+  getGlobalPrefsFile,
+} from "../composables/useRpc";
+
+const mockGetPreferences = vi.mocked(getPreferences);
+const mockSetPreferences = vi.mocked(setPreferences);
+const mockGetWorking = vi.mocked(getGlobalPrefsWorking);
+const mockGetFile = vi.mocked(getGlobalPrefsFile);
+
+function makePrefs(overrides: Partial<GlobalPreferences> = {}): GlobalPreferences {
+  return {
+    run_on_batteries: false,
+    run_if_user_active: true,
+    run_gpu_if_user_active: false,
+    idle_time_to_run: 3,
+    max_ncpus_pct: 100,
+    cpu_usage_limit: 100,
+    ram_max_used_busy_frac: 0.5,
+    ram_max_used_idle_frac: 0.9,
+    max_bytes_sec_down: 0,
+    max_bytes_sec_up: 0,
+    daily_xfer_limit_mb: 0,
+    daily_xfer_period_days: 0,
+    disk_max_used_gb: 100,
+    disk_max_used_pct: 90,
+    disk_min_free_gb: 0.1,
+    disk_interval: 60,
+    work_buf_min_days: 0.1,
+    cpu_scheduling_period_minutes: 60,
+    start_hour: 0,
+    end_hour: 0,
+    net_start_hour: 0,
+    net_end_hour: 0,
+    suspend_if_no_recent_input: 0,
+    suspend_cpu_usage: 25,
+    niu_suspend_cpu_usage: 50,
+    niu_cpu_usage_limit: 100,
+    niu_max_ncpus_pct: 100,
+    leave_apps_in_memory: false,
+    dont_verify_images: false,
+    confirm_before_connecting: false,
+    hangup_if_dialed: false,
+    network_wifi_only: false,
+    work_buf_additional_days: 0.5,
+    max_ncpus: 0,
+    battery_charge_min_pct: 90,
+    battery_max_temperature: 40,
+    vm_max_used_frac: 0.75,
+    day_prefs: [],
+    ...overrides,
+  };
+}
+
+describe("usePreferencesStore", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("starts with null prefs", () => {
+    const store = usePreferencesStore();
+    expect(store.prefs).toBeNull();
+    expect(store.workingPrefs).toBeNull();
+    expect(store.filePrefs).toBeNull();
+    expect(store.loading).toBe(false);
+  });
+
+  it("fetchPreferences loads all three pref sources", async () => {
+    const overridePrefs = makePrefs({ cpu_usage_limit: 80 });
+    const workingPrefs = makePrefs({ cpu_usage_limit: 80 });
+    const filePrefs = makePrefs({ cpu_usage_limit: 100 });
+
+    mockGetPreferences.mockResolvedValueOnce(overridePrefs);
+    mockGetWorking.mockResolvedValueOnce(workingPrefs);
+    mockGetFile.mockResolvedValueOnce(filePrefs);
+
+    const store = usePreferencesStore();
+    await store.fetchPreferences();
+
+    expect(store.prefs).toEqual(overridePrefs);
+    expect(store.workingPrefs).toEqual(workingPrefs);
+    expect(store.filePrefs).toEqual(filePrefs);
+    expect(store.prefetched).toBe(true);
+    expect(store.loading).toBe(false);
+  });
+
+  it("fetchPreferences handles getGlobalPrefsFile failure gracefully", async () => {
+    mockGetPreferences.mockResolvedValueOnce(makePrefs());
+    mockGetWorking.mockResolvedValueOnce(makePrefs());
+    mockGetFile.mockRejectedValueOnce(new Error("Not found"));
+
+    const store = usePreferencesStore();
+    await store.fetchPreferences();
+
+    expect(store.prefs).not.toBeNull();
+    expect(store.filePrefs).toBeNull();
+    expect(store.error).toBeNull();
+  });
+
+  it("fetchPreferences sets error on main failure", async () => {
+    mockGetPreferences.mockRejectedValueOnce(new Error("RPC fail"));
+    mockGetWorking.mockResolvedValueOnce(makePrefs());
+    mockGetFile.mockResolvedValueOnce(makePrefs());
+
+    const store = usePreferencesStore();
+    await store.fetchPreferences();
+
+    expect(store.error).toBe("Error: RPC fail");
+    expect(store.loading).toBe(false);
+  });
+
+  it("prefetchPreferences only runs once", async () => {
+    mockGetPreferences.mockResolvedValue(makePrefs());
+    mockGetWorking.mockResolvedValue(makePrefs());
+    mockGetFile.mockResolvedValue(makePrefs());
+
+    const store = usePreferencesStore();
+    await store.prefetchPreferences();
+    await store.prefetchPreferences();
+
+    expect(mockGetPreferences).toHaveBeenCalledTimes(1);
+  });
+
+  it("getEffectiveValue returns numeric value from workingPrefs", async () => {
+    mockGetPreferences.mockResolvedValueOnce(makePrefs());
+    mockGetWorking.mockResolvedValueOnce(makePrefs({ cpu_usage_limit: 75 }));
+    mockGetFile.mockResolvedValueOnce(makePrefs());
+
+    const store = usePreferencesStore();
+    await store.fetchPreferences();
+
+    expect(store.getEffectiveValue("cpu_usage_limit")).toBe(75);
+  });
+
+  it("getEffectiveValue returns null when workingPrefs not loaded", () => {
+    const store = usePreferencesStore();
+    expect(store.getEffectiveValue("cpu_usage_limit")).toBeNull();
+  });
+
+  it("getFileValue returns numeric value from filePrefs", async () => {
+    mockGetPreferences.mockResolvedValueOnce(makePrefs());
+    mockGetWorking.mockResolvedValueOnce(makePrefs());
+    mockGetFile.mockResolvedValueOnce(makePrefs({ disk_max_used_gb: 200 }));
+
+    const store = usePreferencesStore();
+    await store.fetchPreferences();
+
+    expect(store.getFileValue("disk_max_used_gb")).toBe(200);
+  });
+
+  it("getBoolEffectiveValue returns boolean from workingPrefs", async () => {
+    mockGetPreferences.mockResolvedValueOnce(makePrefs());
+    mockGetWorking.mockResolvedValueOnce(makePrefs({ run_on_batteries: true }));
+    mockGetFile.mockResolvedValueOnce(makePrefs());
+
+    const store = usePreferencesStore();
+    await store.fetchPreferences();
+
+    expect(store.getBoolEffectiveValue("run_on_batteries")).toBe(true);
+  });
+
+  it("savePreferences calls RPC and updates state", async () => {
+    const newPrefs = makePrefs({ cpu_usage_limit: 50 });
+    mockSetPreferences.mockResolvedValueOnce(undefined);
+    mockGetWorking.mockResolvedValueOnce(makePrefs({ cpu_usage_limit: 50 }));
+
+    const store = usePreferencesStore();
+    await store.savePreferences(newPrefs);
+
+    expect(mockSetPreferences).toHaveBeenCalledWith(newPrefs);
+    expect(store.prefs).toEqual(newPrefs);
+    expect(store.saving).toBe(false);
+  });
+
+  it("savePreferences sets error on failure", async () => {
+    mockSetPreferences.mockRejectedValueOnce(new Error("Save failed"));
+
+    const store = usePreferencesStore();
+    await store.savePreferences(makePrefs());
+
+    expect(store.error).toBe("Error: Save failed");
+    expect(store.saving).toBe(false);
+  });
+});

--- a/src/stores/statistics.test.ts
+++ b/src/stores/statistics.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { setActivePinia, createPinia } from "pinia";
+import { useStatisticsStore } from "./statistics";
+import type { ProjectStatistics } from "../types/boinc";
+
+vi.mock("../composables/useRpc", () => ({
+  getStatistics: vi.fn(),
+}));
+
+import { getStatistics } from "../composables/useRpc";
+
+const mockGetStatistics = vi.mocked(getStatistics);
+
+const sampleStats: ProjectStatistics[] = [
+  {
+    master_url: "https://example.com/",
+    daily_statistics: [
+      { day: 1700000000, user_total_credit: 1000, user_expavg_credit: 100, host_total_credit: 500, host_expavg_credit: 50 },
+    ],
+  },
+];
+
+describe("useStatisticsStore", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("starts with empty stats", () => {
+    const store = useStatisticsStore();
+    expect(store.projectStats).toEqual([]);
+    expect(store.loading).toBe(false);
+    expect(store.error).toBeNull();
+  });
+
+  it("fetchStatistics populates data", async () => {
+    mockGetStatistics.mockResolvedValueOnce(sampleStats);
+    const store = useStatisticsStore();
+    await store.fetchStatistics();
+    expect(store.projectStats).toEqual(sampleStats);
+    expect(store.loading).toBe(false);
+  });
+
+  it("fetchStatistics sets error on failure", async () => {
+    mockGetStatistics.mockRejectedValueOnce(new Error("Timeout"));
+    const store = useStatisticsStore();
+    await store.fetchStatistics();
+    expect(store.error).toBe("Error: Timeout");
+    expect(store.loading).toBe(false);
+  });
+
+  it("polls and stops", async () => {
+    mockGetStatistics.mockResolvedValue(sampleStats);
+    const store = useStatisticsStore();
+    store.startPolling(1000);
+
+    await vi.advanceTimersByTimeAsync(100);
+    const initialCalls = mockGetStatistics.mock.calls.length;
+    expect(initialCalls).toBeGreaterThanOrEqual(1);
+
+    store.stopPolling();
+    const afterStop = mockGetStatistics.mock.calls.length;
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(mockGetStatistics.mock.calls.length).toBe(afterStop);
+  });
+});

--- a/src/stores/toast.test.ts
+++ b/src/stores/toast.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { setActivePinia, createPinia } from "pinia";
+import { useToastStore } from "./toast";
+
+describe("useToastStore", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("starts with empty toasts", () => {
+    const store = useToastStore();
+    expect(store.toasts).toEqual([]);
+  });
+
+  it("show() adds a toast with correct type", () => {
+    const store = useToastStore();
+    store.show("Hello", "success");
+    expect(store.toasts).toHaveLength(1);
+    expect(store.toasts[0]).toMatchObject({ message: "Hello", type: "success" });
+  });
+
+  it("show() defaults to info type", () => {
+    const store = useToastStore();
+    store.show("Info message");
+    expect(store.toasts[0].type).toBe("info");
+  });
+
+  it("dismiss() removes a toast by id", () => {
+    const store = useToastStore();
+    store.show("First", "info", 0);
+    store.show("Second", "info", 0);
+    const idToRemove = store.toasts[0].id;
+    store.dismiss(idToRemove);
+    expect(store.toasts).toHaveLength(1);
+    expect(store.toasts[0].message).toBe("Second");
+  });
+
+  it("auto-dismisses after duration", () => {
+    const store = useToastStore();
+    store.show("Auto", "info", 2000);
+    expect(store.toasts).toHaveLength(1);
+    vi.advanceTimersByTime(2000);
+    expect(store.toasts).toHaveLength(0);
+  });
+
+  it("duration 0 does not auto-dismiss", () => {
+    const store = useToastStore();
+    store.show("Sticky", "error", 0);
+    vi.advanceTimersByTime(10000);
+    expect(store.toasts).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Add unit tests for 6 stores that had zero test coverage: toast, diskUsage, statistics, notices, managerSettings, preferences
- 37 new tests covering initial state, fetch/save operations, error handling, polling, and localStorage persistence
- Total test count: 246 → 283

## Test plan
- [ ] `pnpm test` — all 283 tests pass
- [ ] `pnpm build` — no TypeScript errors

🤖 Reviewed with Codex before submission.