### PR TITLE
fix: add handleConnectionError to 4 stores missing reconnect logic

### DIFF
--- a/src/stores/diskUsage.test.ts
+++ b/src/stores/diskUsage.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { setActivePinia, createPinia } from "pinia";
 import { useDiskUsageStore } from "./diskUsage";
+import { useConnectionStore } from "./connection";
 import type { DiskUsage } from "../types/boinc";
 
 vi.mock("../composables/useRpc", () => ({
@@ -49,8 +50,19 @@ describe("useDiskUsageStore", () => {
     mockGetDiskUsage.mockRejectedValueOnce(new Error("Network error"));
     const store = useDiskUsageStore();
     await store.fetchDiskUsage();
-    expect(store.error).toBe("Error: Network error");
+    expect(store.error).toBe("Network error");
     expect(store.loading).toBe(false);
+  });
+
+  it("fetchDiskUsage triggers handleConnectionError on failure", async () => {
+    mockGetDiskUsage.mockRejectedValueOnce(new Error("Network error"));
+    const connection = useConnectionStore();
+    const spy = vi.spyOn(connection, "handleConnectionError");
+
+    const store = useDiskUsageStore();
+    await store.fetchDiskUsage();
+
+    expect(spy).toHaveBeenCalledOnce();
   });
 
   it("polls and stops", async () => {

--- a/src/stores/diskUsage.ts
+++ b/src/stores/diskUsage.ts
@@ -2,6 +2,7 @@ import { defineStore } from "pinia";
 import { ref } from "vue";
 import { getDiskUsage } from "../composables/useRpc";
 import type { DiskUsage } from "../types/boinc";
+import { useConnectionStore } from "./connection";
 
 const POLL_INTERVAL_MS = 30000;
 
@@ -23,7 +24,9 @@ export const useDiskUsageStore = defineStore("diskUsage", () => {
     try {
       usage.value = await getDiskUsage();
     } catch (e) {
-      error.value = String(e);
+      error.value = e instanceof Error ? e.message : String(e);
+      const connection = useConnectionStore();
+      connection.handleConnectionError();
     } finally {
       loading.value = false;
     }

--- a/src/stores/messages.test.ts
+++ b/src/stores/messages.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { setActivePinia, createPinia } from "pinia";
 import { useMessagesStore } from "./messages";
+import { useConnectionStore } from "./connection";
 import type { Message } from "../types/boinc";
 import { MSG_PRIORITY } from "../types/boinc";
 
@@ -185,6 +186,33 @@ describe("useMessagesStore", () => {
 
     expect(store.error).toBe("Connection lost");
     expect(store.messages).toEqual([]);
+  });
+
+  it("fetchMessages triggers handleConnectionError on failure", async () => {
+    mockInvoke.mockRejectedValueOnce("Connection lost");
+    const connection = useConnectionStore();
+    const spy = vi.spyOn(connection, "handleConnectionError");
+
+    const store = useMessagesStore();
+    await store.fetchMessages();
+
+    expect(spy).toHaveBeenCalledOnce();
+  });
+
+  it("fetchOlderMessages triggers handleConnectionError on failure", async () => {
+    const all = Array.from({ length: 100 }, (_, i) => makeMessage(i + 1));
+    stubRpc(100, all);
+
+    const store = useMessagesStore();
+    await store.fetchMessages();
+
+    mockInvoke.mockRejectedValueOnce("Network error");
+    const connection = useConnectionStore();
+    const spy = vi.spyOn(connection, "handleConnectionError");
+
+    await store.fetchOlderMessages();
+
+    expect(spy).toHaveBeenCalledOnce();
   });
 
   it("filteredMessages filters by search text", async () => {

--- a/src/stores/messages.ts
+++ b/src/stores/messages.ts
@@ -2,6 +2,7 @@ import { defineStore } from "pinia";
 import { computed, ref } from "vue";
 import { getMessages, getMessageCount } from "../composables/useRpc";
 import type { Message } from "../types/boinc";
+import { useConnectionStore } from "./connection";
 
 const POLL_INTERVAL_MS = 5000;
 const PAGE_SIZE = 50;
@@ -54,7 +55,9 @@ export const useMessagesStore = defineStore("messages", () => {
         }
       }
     } catch (e) {
-      error.value = String(e);
+      error.value = e instanceof Error ? e.message : String(e);
+      const connection = useConnectionStore();
+      connection.handleConnectionError();
     } finally {
       loading.value = false;
     }
@@ -85,7 +88,9 @@ export const useMessagesStore = defineStore("messages", () => {
 
       hasMore.value = startSeqno > 0 && filtered.length > 0;
     } catch (e) {
-      error.value = String(e);
+      error.value = e instanceof Error ? e.message : String(e);
+      const connection = useConnectionStore();
+      connection.handleConnectionError();
     } finally {
       loadingMore.value = false;
     }

--- a/src/stores/notices.test.ts
+++ b/src/stores/notices.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { setActivePinia, createPinia } from "pinia";
 import { useNoticesStore } from "./notices";
+import { useConnectionStore } from "./connection";
 import type { Notice } from "../types/boinc";
 
 vi.mock("../composables/useRpc", () => ({
@@ -88,8 +89,19 @@ describe("useNoticesStore", () => {
     const store = useNoticesStore();
     await store.fetchNotices();
 
-    expect(store.error).toBe("Error: Connection lost");
+    expect(store.error).toBe("Connection lost");
     expect(store.loading).toBe(false);
+  });
+
+  it("fetchNotices triggers handleConnectionError on failure", async () => {
+    mockGetNotices.mockRejectedValueOnce(new Error("Connection lost"));
+    const connection = useConnectionStore();
+    const spy = vi.spyOn(connection, "handleConnectionError");
+
+    const store = useNoticesStore();
+    await store.fetchNotices();
+
+    expect(spy).toHaveBeenCalledOnce();
   });
 
   it("polls and stops", async () => {

--- a/src/stores/notices.ts
+++ b/src/stores/notices.ts
@@ -3,6 +3,7 @@ import { ref } from "vue";
 import { getNotices } from "../composables/useRpc";
 import { notifyNewNotices } from "../composables/useNotifications";
 import type { Notice } from "../types/boinc";
+import { useConnectionStore } from "./connection";
 
 const POLL_INTERVAL_MS = 30000;
 
@@ -24,7 +25,9 @@ export const useNoticesStore = defineStore("notices", () => {
         notifyNewNotices(newNotices.length);
       }
     } catch (e) {
-      error.value = String(e);
+      error.value = e instanceof Error ? e.message : String(e);
+      const connection = useConnectionStore();
+      connection.handleConnectionError();
     } finally {
       loading.value = false;
     }

--- a/src/stores/statistics.test.ts
+++ b/src/stores/statistics.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { setActivePinia, createPinia } from "pinia";
 import { useStatisticsStore } from "./statistics";
+import { useConnectionStore } from "./connection";
 import type { ProjectStatistics } from "../types/boinc";
 
 vi.mock("../composables/useRpc", () => ({
@@ -50,8 +51,19 @@ describe("useStatisticsStore", () => {
     mockGetStatistics.mockRejectedValueOnce(new Error("Timeout"));
     const store = useStatisticsStore();
     await store.fetchStatistics();
-    expect(store.error).toBe("Error: Timeout");
+    expect(store.error).toBe("Timeout");
     expect(store.loading).toBe(false);
+  });
+
+  it("fetchStatistics triggers handleConnectionError on failure", async () => {
+    mockGetStatistics.mockRejectedValueOnce(new Error("Timeout"));
+    const connection = useConnectionStore();
+    const spy = vi.spyOn(connection, "handleConnectionError");
+
+    const store = useStatisticsStore();
+    await store.fetchStatistics();
+
+    expect(spy).toHaveBeenCalledOnce();
   });
 
   it("polls and stops", async () => {

--- a/src/stores/statistics.ts
+++ b/src/stores/statistics.ts
@@ -2,6 +2,7 @@ import { defineStore } from "pinia";
 import { ref } from "vue";
 import { getStatistics } from "../composables/useRpc";
 import type { ProjectStatistics } from "../types/boinc";
+import { useConnectionStore } from "./connection";
 
 const POLL_INTERVAL_MS = 60000;
 
@@ -17,7 +18,9 @@ export const useStatisticsStore = defineStore("statistics", () => {
     try {
       projectStats.value = await getStatistics();
     } catch (e) {
-      error.value = String(e);
+      error.value = e instanceof Error ? e.message : String(e);
+      const connection = useConnectionStore();
+      connection.handleConnectionError();
     } finally {
       loading.value = false;
     }


### PR DESCRIPTION
## Summary
- Add `handleConnectionError()` to `statistics`, `diskUsage`, `notices`, and `messages` stores (5 catch sites)
- These stores silently swallowed fetch errors without triggering auto-reconnect, unlike `tasks`/`projects`/`transfers`/`client`
- Fix error format consistency: `e instanceof Error ? e.message : String(e)` (removes redundant "Error: " prefix)
- Update all 4 test files to verify `handleConnectionError` is called on failure

Closes #53

## Test plan
- [ ] All 283 tests pass
- [ ] Disconnect BOINC client while on Statistics/Disk Usage/Notices/Event Log page → app should trigger reconnect flow

🤖 Reviewed with Codex before submission.