### PR TITLE
fix(a11y): use role="switch" with aria-checked on toggle switches

### DIFF
--- a/src/components/LogFlagsDialog.vue
+++ b/src/components/LogFlagsDialog.vue
@@ -102,7 +102,8 @@ async function save() {
                 <span
                   class="toggle-switch"
                   :class="{ on: config.log_flags[flag.key] }"
-                  role="button"
+                  role="switch"
+                  :aria-checked="!!(config.log_flags[flag.key])"
                   tabindex="0"
                   @click.stop="config.log_flags[flag.key] = !config.log_flags[flag.key]"
                   @keydown.enter.prevent="config.log_flags[flag.key] = !config.log_flags[flag.key]"
@@ -139,7 +140,8 @@ async function save() {
                 <span
                   class="toggle-switch"
                   :class="{ on: config.report_results_immediately }"
-                  role="button"
+                  role="switch"
+                  :aria-checked="!!(config.report_results_immediately)"
                   tabindex="0"
                   @click.stop="config.report_results_immediately = !config.report_results_immediately"
                   @keydown.enter.prevent="config.report_results_immediately = !config.report_results_immediately"

--- a/src/components/PrefToggleSwitch.test.ts
+++ b/src/components/PrefToggleSwitch.test.ts
@@ -60,11 +60,17 @@ describe("PrefToggleSwitch", () => {
     expect(wrapper.emitted("update:modelValue")).toEqual([[true]]);
   });
 
-  it("toggle-switch has role=button and tabindex=0", () => {
+  it("toggle-switch has role=switch, aria-checked, and tabindex=0", () => {
     const wrapper = mountToggle(false);
     const toggle = wrapper.find(".toggle-switch");
-    expect(toggle.attributes("role")).toBe("button");
+    expect(toggle.attributes("role")).toBe("switch");
+    expect(toggle.attributes("aria-checked")).toBe("false");
     expect(toggle.attributes("tabindex")).toBe("0");
+  });
+
+  it("aria-checked reflects modelValue=true", () => {
+    const wrapper = mountToggle(true);
+    expect(wrapper.find(".toggle-switch").attributes("aria-checked")).toBe("true");
   });
 
   describe("sourceType", () => {

--- a/src/components/PrefToggleSwitch.vue
+++ b/src/components/PrefToggleSwitch.vue
@@ -98,7 +98,8 @@ function onClearOverride() {
       <span
         class="toggle-switch"
         :class="{ on: modelValue }"
-        role="button"
+        role="switch"
+        :aria-checked="modelValue"
         tabindex="0"
         @click.prevent="emit('update:modelValue', !modelValue)"
         @keydown.enter.prevent="emit('update:modelValue', !modelValue)"

--- a/src/components/PreferencesDialog.vue
+++ b/src/components/PreferencesDialog.vue
@@ -385,7 +385,7 @@ async function save() {
                 <div v-for="(day, i) in dayNames" :key="i" class="schedule-day">
                   <div class="schedule-day-header">
                     <label class="day-toggle">
-                      <span class="toggle-switch toggle-sm" :class="{ on: dayEnabled[i] }" role="button" tabindex="0" @click.prevent="toggleDay(i, !dayEnabled[i])" @keydown.enter.prevent="toggleDay(i, !dayEnabled[i])" @keydown.space.prevent="toggleDay(i, !dayEnabled[i])">
+                      <span class="toggle-switch toggle-sm" :class="{ on: dayEnabled[i] }" role="switch" :aria-checked="!!(dayEnabled[i])" tabindex="0" @click.prevent="toggleDay(i, !dayEnabled[i])" @keydown.enter.prevent="toggleDay(i, !dayEnabled[i])" @keydown.space.prevent="toggleDay(i, !dayEnabled[i])">
                         <span class="toggle-knob" />
                       </span>
                       <span class="day-name">{{ day }}</span>
@@ -447,28 +447,28 @@ async function save() {
 
               <label class="pref-row">
                 <span>{{ $t('prefs.manager.showExitConfirm') }}</span>
-                <span class="toggle-switch" :class="{ on: managerForm.showExitConfirmation }" role="button" tabindex="0" @click.prevent="managerForm.showExitConfirmation = !managerForm.showExitConfirmation" @keydown.enter.prevent="managerForm.showExitConfirmation = !managerForm.showExitConfirmation" @keydown.space.prevent="managerForm.showExitConfirmation = !managerForm.showExitConfirmation">
+                <span class="toggle-switch" :class="{ on: managerForm.showExitConfirmation }" role="switch" :aria-checked="!!(managerForm.showExitConfirmation)" tabindex="0" @click.prevent="managerForm.showExitConfirmation = !managerForm.showExitConfirmation" @keydown.enter.prevent="managerForm.showExitConfirmation = !managerForm.showExitConfirmation" @keydown.space.prevent="managerForm.showExitConfirmation = !managerForm.showExitConfirmation">
                   <span class="toggle-knob" />
                 </span>
               </label>
 
               <label class="pref-row">
                 <span>{{ $t('prefs.manager.showShutdownConfirm') }}</span>
-                <span class="toggle-switch" :class="{ on: managerForm.showShutdownConfirmation }" role="button" tabindex="0" @click.prevent="managerForm.showShutdownConfirmation = !managerForm.showShutdownConfirmation" @keydown.enter.prevent="managerForm.showShutdownConfirmation = !managerForm.showShutdownConfirmation" @keydown.space.prevent="managerForm.showShutdownConfirmation = !managerForm.showShutdownConfirmation">
+                <span class="toggle-switch" :class="{ on: managerForm.showShutdownConfirmation }" role="switch" :aria-checked="!!(managerForm.showShutdownConfirmation)" tabindex="0" @click.prevent="managerForm.showShutdownConfirmation = !managerForm.showShutdownConfirmation" @keydown.enter.prevent="managerForm.showShutdownConfirmation = !managerForm.showShutdownConfirmation" @keydown.space.prevent="managerForm.showShutdownConfirmation = !managerForm.showShutdownConfirmation">
                   <span class="toggle-knob" />
                 </span>
               </label>
 
               <label class="pref-row">
                 <span>{{ $t('prefs.manager.minimizeToTray') }}</span>
-                <span class="toggle-switch" :class="{ on: managerForm.minimizeToTrayOnClose }" role="button" tabindex="0" @click.prevent="managerForm.minimizeToTrayOnClose = !managerForm.minimizeToTrayOnClose" @keydown.enter.prevent="managerForm.minimizeToTrayOnClose = !managerForm.minimizeToTrayOnClose" @keydown.space.prevent="managerForm.minimizeToTrayOnClose = !managerForm.minimizeToTrayOnClose">
+                <span class="toggle-switch" :class="{ on: managerForm.minimizeToTrayOnClose }" role="switch" :aria-checked="!!(managerForm.minimizeToTrayOnClose)" tabindex="0" @click.prevent="managerForm.minimizeToTrayOnClose = !managerForm.minimizeToTrayOnClose" @keydown.enter.prevent="managerForm.minimizeToTrayOnClose = !managerForm.minimizeToTrayOnClose" @keydown.space.prevent="managerForm.minimizeToTrayOnClose = !managerForm.minimizeToTrayOnClose">
                   <span class="toggle-knob" />
                 </span>
               </label>
 
               <label class="pref-row">
                 <span>{{ $t('prefs.manager.startMinimized') }}</span>
-                <span class="toggle-switch" :class="{ on: managerForm.startMinimizedToTray }" role="button" tabindex="0" @click.prevent="managerForm.startMinimizedToTray = !managerForm.startMinimizedToTray" @keydown.enter.prevent="managerForm.startMinimizedToTray = !managerForm.startMinimizedToTray" @keydown.space.prevent="managerForm.startMinimizedToTray = !managerForm.startMinimizedToTray">
+                <span class="toggle-switch" :class="{ on: managerForm.startMinimizedToTray }" role="switch" :aria-checked="!!(managerForm.startMinimizedToTray)" tabindex="0" @click.prevent="managerForm.startMinimizedToTray = !managerForm.startMinimizedToTray" @keydown.enter.prevent="managerForm.startMinimizedToTray = !managerForm.startMinimizedToTray" @keydown.space.prevent="managerForm.startMinimizedToTray = !managerForm.startMinimizedToTray">
                   <span class="toggle-knob" />
                 </span>
               </label>

--- a/src/components/ProxySettingsDialog.vue
+++ b/src/components/ProxySettingsDialog.vue
@@ -93,7 +93,7 @@ async function save() {
             <div v-if="activeTab === 'http'" class="proxy-section">
               <label class="pref-row">
                 <span>{{ $t('proxy.useHttp') }}</span>
-                <span class="toggle-switch" :class="{ on: form.use_http_proxy }" role="button" tabindex="0" @click.prevent="form.use_http_proxy = !form.use_http_proxy" @keydown.enter.prevent="form.use_http_proxy = !form.use_http_proxy" @keydown.space.prevent="form.use_http_proxy = !form.use_http_proxy">
+                <span class="toggle-switch" :class="{ on: form.use_http_proxy }" role="switch" :aria-checked="!!(form.use_http_proxy)" tabindex="0" @click.prevent="form.use_http_proxy = !form.use_http_proxy" @keydown.enter.prevent="form.use_http_proxy = !form.use_http_proxy" @keydown.space.prevent="form.use_http_proxy = !form.use_http_proxy">
                   <span class="toggle-knob" />
                 </span>
               </label>
@@ -108,7 +108,7 @@ async function save() {
                 </label>
                 <label class="pref-row">
                   <span>{{ $t('proxy.useHttpAuth') }}</span>
-                  <span class="toggle-switch" :class="{ on: form.use_http_auth }" role="button" tabindex="0" @click.prevent="form.use_http_auth = !form.use_http_auth" @keydown.enter.prevent="form.use_http_auth = !form.use_http_auth" @keydown.space.prevent="form.use_http_auth = !form.use_http_auth">
+                  <span class="toggle-switch" :class="{ on: form.use_http_auth }" role="switch" :aria-checked="!!(form.use_http_auth)" tabindex="0" @click.prevent="form.use_http_auth = !form.use_http_auth" @keydown.enter.prevent="form.use_http_auth = !form.use_http_auth" @keydown.space.prevent="form.use_http_auth = !form.use_http_auth">
                     <span class="toggle-knob" />
                   </span>
                 </label>
@@ -129,7 +129,7 @@ async function save() {
             <div v-if="activeTab === 'socks'" class="proxy-section">
               <label class="pref-row">
                 <span>{{ $t('proxy.useSocks') }}</span>
-                <span class="toggle-switch" :class="{ on: form.use_socks_proxy }" role="button" tabindex="0" @click.prevent="form.use_socks_proxy = !form.use_socks_proxy" @keydown.enter.prevent="form.use_socks_proxy = !form.use_socks_proxy" @keydown.space.prevent="form.use_socks_proxy = !form.use_socks_proxy">
+                <span class="toggle-switch" :class="{ on: form.use_socks_proxy }" role="switch" :aria-checked="!!(form.use_socks_proxy)" tabindex="0" @click.prevent="form.use_socks_proxy = !form.use_socks_proxy" @keydown.enter.prevent="form.use_socks_proxy = !form.use_socks_proxy" @keydown.space.prevent="form.use_socks_proxy = !form.use_socks_proxy">
                   <span class="toggle-knob" />
                 </span>
               </label>
@@ -152,7 +152,7 @@ async function save() {
                 </label>
                 <label class="pref-row">
                   <span>{{ $t('proxy.useSocks5Dns') }}</span>
-                  <span class="toggle-switch" :class="{ on: form.socks5_remote_dns }" role="button" tabindex="0" @click.prevent="form.socks5_remote_dns = !form.socks5_remote_dns" @keydown.enter.prevent="form.socks5_remote_dns = !form.socks5_remote_dns" @keydown.space.prevent="form.socks5_remote_dns = !form.socks5_remote_dns">
+                  <span class="toggle-switch" :class="{ on: form.socks5_remote_dns }" role="switch" :aria-checked="!!(form.socks5_remote_dns)" tabindex="0" @click.prevent="form.socks5_remote_dns = !form.socks5_remote_dns" @keydown.enter.prevent="form.socks5_remote_dns = !form.socks5_remote_dns" @keydown.space.prevent="form.socks5_remote_dns = !form.socks5_remote_dns">
                     <span class="toggle-knob" />
                   </span>
                 </label>


### PR DESCRIPTION
## Summary
- Replace `role="button"` with `role="switch"` and add `:aria-checked` on all 12 toggle switch elements across 4 components
- Ensures screen readers (VoiceOver, NVDA) announce toggles as switches with on/off state per WCAG 4.1.2
- Updated existing test to verify `role="switch"` and `aria-checked` attributes

## Affected components
| Component | Toggles |
|-----------|---------|
| `PrefToggleSwitch.vue` | 1 |
| `PreferencesDialog.vue` | 5 |
| `ProxySettingsDialog.vue` | 4 |
| `LogFlagsDialog.vue` | 2 |

## Test plan
- [x] All 284 tests pass
- [x] 0 lint errors
- [ ] VoiceOver announces toggles as "switch, on/off" instead of "button"
- [ ] Keyboard interaction (Enter/Space) still works correctly

Closes #55

🤖 Reviewed with Codex before submission.