### PR TITLE
fix: replace hardcoded status colors with CSS variables for dark mode

### DIFF
--- a/src/components/StatusBadge.vue
+++ b/src/components/StatusBadge.vue
@@ -29,21 +29,21 @@ defineProps<{
 
 .badge-success {
   background: var(--color-success-light);
-  color: #15803d;
+  color: var(--color-success-text);
 }
 
 .badge-warning {
   background: var(--color-warning-light);
-  color: #92400e;
+  color: var(--color-warning-text);
 }
 
 .badge-danger {
   background: var(--color-danger-light);
-  color: #991b1b;
+  color: var(--color-danger-text);
 }
 
 .badge-info {
   background: var(--color-accent-light);
-  color: #1d4ed8;
+  color: var(--color-accent-text);
 }
 </style>

--- a/src/components/ToastContainer.vue
+++ b/src/components/ToastContainer.vue
@@ -54,13 +54,13 @@ const toast = useToastStore();
 }
 
 .toast-success {
-  background: #065f46;
-  color: #d1fae5;
+  background: var(--color-toast-success-bg);
+  color: var(--color-toast-success-text);
 }
 
 .toast-error {
-  background: #991b1b;
-  color: #fee2e2;
+  background: var(--color-toast-error-bg);
+  color: var(--color-toast-error-text);
 }
 
 .toast-info {

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -16,8 +16,18 @@
   --color-danger-light: #fef2f2;
   --color-success: #22c55e;
   --color-success-light: #f0fdf4;
+  --color-success-text: #15803d;
   --color-warning: #f59e0b;
   --color-warning-light: #fffbeb;
+  --color-warning-text: #92400e;
+  --color-danger-text: #991b1b;
+  --color-accent-text: #1d4ed8;
+
+  /* Toast (self-contained floating pills) */
+  --color-toast-success-bg: #065f46;
+  --color-toast-success-text: #d1fae5;
+  --color-toast-error-bg: #991b1b;
+  --color-toast-error-text: #fee2e2;
 
   /* Radius */
   --radius-sm: 6px;
@@ -92,8 +102,17 @@
     --color-danger-light: rgba(248, 113, 113, 0.15);
     --color-success: #4ade80;
     --color-success-light: rgba(74, 222, 128, 0.15);
+    --color-success-text: #86efac;
     --color-warning: #fbbf24;
     --color-warning-light: rgba(251, 191, 36, 0.15);
+    --color-warning-text: #fcd34d;
+    --color-danger-text: #fca5a5;
+    --color-accent-text: #93c5fd;
+
+    --color-toast-success-bg: #064e3b;
+    --color-toast-success-text: #d1fae5;
+    --color-toast-error-bg: #7f1d1d;
+    --color-toast-error-text: #fee2e2;
 
     /* Shadows */
     --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.3);
@@ -124,8 +143,17 @@
   --color-danger-light: #fef2f2;
   --color-success: #22c55e;
   --color-success-light: #f0fdf4;
+  --color-success-text: #15803d;
   --color-warning: #f59e0b;
   --color-warning-light: #fffbeb;
+  --color-warning-text: #92400e;
+  --color-danger-text: #991b1b;
+  --color-accent-text: #1d4ed8;
+
+  --color-toast-success-bg: #065f46;
+  --color-toast-success-text: #d1fae5;
+  --color-toast-error-bg: #991b1b;
+  --color-toast-error-text: #fee2e2;
 
   --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.05);
   --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.07),
@@ -154,8 +182,17 @@
   --color-danger-light: rgba(248, 113, 113, 0.15);
   --color-success: #4ade80;
   --color-success-light: rgba(74, 222, 128, 0.15);
+  --color-success-text: #86efac;
   --color-warning: #fbbf24;
   --color-warning-light: rgba(251, 191, 36, 0.15);
+  --color-warning-text: #fcd34d;
+  --color-danger-text: #fca5a5;
+  --color-accent-text: #93c5fd;
+
+  --color-toast-success-bg: #064e3b;
+  --color-toast-success-text: #d1fae5;
+  --color-toast-error-bg: #7f1d1d;
+  --color-toast-error-text: #fee2e2;
 
   --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.3);
   --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.4),

--- a/src/views/MessagesView.vue
+++ b/src/views/MessagesView.vue
@@ -432,7 +432,7 @@ onUnmounted(() => {
 }
 
 :deep(.row-error) td {
-  color: #991b1b;
+  color: var(--color-danger-text);
 }
 
 :deep(.row-alert) {
@@ -440,7 +440,7 @@ onUnmounted(() => {
 }
 
 :deep(.row-alert) td {
-  color: #92400e;
+  color: var(--color-warning-text);
 }
 
 :deep(.row-selected) {

--- a/src/views/ProjectsView.vue
+++ b/src/views/ProjectsView.vue
@@ -600,7 +600,7 @@ function isColVisible(key: string): boolean {
 
 .source-manager {
   background: var(--color-accent-light);
-  color: #1d4ed8;
+  color: var(--color-accent-text);
 }
 
 .source-user {


### PR DESCRIPTION
## Summary
- Add `--color-{success,warning,danger,accent}-text` and toast color tokens to `tokens.css` with proper light/dark mode variants
- Replace all hardcoded hex color values in `StatusBadge`, `ToastContainer`, `MessagesView` error/alert rows, and `ProjectsView` source badge with the new CSS variables
- Light mode uses Tailwind 700-800 shades; dark mode uses 300 shades for sufficient contrast

## Before / After

| Component | Before (dark mode) | After (dark mode) |
|-----------|--------------------|--------------------|
| StatusBadge | Dark text (#15803d) on dark bg — unreadable | Light text (#86efac) — readable |
| MessagesView errors | Dark red (#991b1b) on dark bg | Light red (#fca5a5) |
| Toast | Fixed colors, no theme adaptation | Slightly adjusted dark mode bg for better integration |

## Test plan
- [x] All 295 tests pass
- [x] 0 lint errors
- [ ] Toggle between light/dark theme — all status badges, toasts, error/alert rows remain readable
- [ ] Verify contrast ratio ≥ 4.5:1 (WCAG AA) for all text-on-background combinations

Closes #57

🤖 Reviewed with Codex before submission.