### PR TITLE
fix: add ARIA progressbar role and value attributes

### DIFF
--- a/src/views/TasksView.test.ts
+++ b/src/views/TasksView.test.ts
@@ -3,6 +3,7 @@ import { mount } from "@vue/test-utils";
 import { setActivePinia, createPinia } from "pinia";
 import TasksView from "./TasksView.vue";
 import { useTasksStore } from "../stores/tasks";
+import { useProjectsStore } from "../stores/projects";
 import type { TaskResult } from "../types/boinc";
 
 vi.mock("@tauri-apps/api/core", () => ({
@@ -161,6 +162,24 @@ describe("TasksView", () => {
     const body = document.body.textContent ?? "";
     expect(body).toContain("Abort Tasks");
     expect(body).toContain("cannot be undone");
+  });
+
+  it("progress bar has ARIA progressbar attributes", () => {
+    const store = useTasksStore();
+    const projectsStore = useProjectsStore();
+    projectsStore.projects = [
+      { master_url: "https://example.com/", project_name: "Climate Model" } as never,
+    ];
+    store.tasks = [makeTask({ wu_name: "climate_sim_42", fraction_done: 0.456 })];
+
+    const wrapper = mount(TasksView);
+    const bar = wrapper.find(".progress-bar");
+    expect(bar.attributes("role")).toBe("progressbar");
+    expect(bar.attributes("aria-valuenow")).toBe("46");
+    expect(bar.attributes("aria-valuemin")).toBe("0");
+    expect(bar.attributes("aria-valuemax")).toBe("100");
+    expect(bar.attributes("aria-label")).toBe("Climate Model");
+    expect(bar.attributes("aria-valuetext")).toBe("45.60%");
   });
 
   it("opens abort confirmation when Backspace is pressed with selection", async () => {

--- a/src/views/TasksView.vue
+++ b/src/views/TasksView.vue
@@ -466,7 +466,15 @@ function isColVisible(key: string): boolean {
         </td>
         <td v-if="isColVisible('project')" class="col-project" :title="task.project_url">{{ projectName(task.project_url) }}</td>
         <td v-if="isColVisible('progress')" class="col-progress">
-          <div class="progress-bar">
+          <div
+            class="progress-bar"
+            role="progressbar"
+            :aria-valuenow="Math.min(100, Math.max(0, Math.round(task.fraction_done * 100)))"
+            aria-valuemin="0"
+            aria-valuemax="100"
+            :aria-label="projectName(task.project_url)"
+            :aria-valuetext="formatPercent(task.fraction_done)"
+          >
             <div
               class="progress-fill"
               :style="{ width: formatPercent(task.fraction_done) }"

--- a/src/views/TransfersView.test.ts
+++ b/src/views/TransfersView.test.ts
@@ -84,6 +84,20 @@ describe("TransfersView", () => {
     expect(body).toContain("Abort 1 selected transfer?");
   });
 
+  it("progress bar has ARIA progressbar attributes", () => {
+    const store = useTransfersStore();
+    store.transfers = [makeTransfer({ bytes_xferred: 524288, nbytes: 1048576 })]; // 50%
+
+    const wrapper = mount(TransfersView);
+    const bar = wrapper.find(".progress-bar");
+    expect(bar.attributes("role")).toBe("progressbar");
+    expect(bar.attributes("aria-valuenow")).toBe("50");
+    expect(bar.attributes("aria-valuemin")).toBe("0");
+    expect(bar.attributes("aria-valuemax")).toBe("100");
+    expect(bar.attributes("aria-label")).toBe("Example Project");
+    expect(bar.attributes("aria-valuetext")).toBe("50.0%");
+  });
+
   it("opens abort confirmation when Backspace is pressed with selection", async () => {
     const store = useTransfersStore();
     store.transfers = [makeTransfer()];

--- a/src/views/TransfersView.vue
+++ b/src/views/TransfersView.vue
@@ -305,7 +305,15 @@ function isColVisible(key: string): boolean {
         <td v-if="isColVisible('project')">{{ transfer.project_name }}</td>
         <td v-if="isColVisible('direction')">{{ transferDirection(transfer) }}</td>
         <td v-if="isColVisible('progress')" class="col-progress">
-          <div class="progress-bar">
+          <div
+            class="progress-bar"
+            role="progressbar"
+            :aria-valuenow="Math.min(100, Math.max(0, Math.round(transferProgress(transfer) * 100)))"
+            aria-valuemin="0"
+            aria-valuemax="100"
+            :aria-label="transfer.project_name"
+            :aria-valuetext="transferProgressText(transfer)"
+          >
             <div
               class="progress-fill"
               :style="{ width: transferProgressText(transfer) }"


### PR DESCRIPTION
## Summary
- Add `role="progressbar"`, `aria-valuenow`, `aria-valuemin="0"`, `aria-valuemax="100"` to progress bars in TasksView and TransfersView
- Screen readers can now announce task/transfer progress (WCAG 4.1.2)
- Add tests for ARIA attributes in both views

Closes #59

## Test plan
- [ ] `npx vitest run` — 297 tests pass
- [ ] `npx vue-tsc --noEmit` — 0 errors
- [ ] Screen reader (VoiceOver) announces progress percentages on Tasks and Transfers pages

🤖 Reviewed with Codex before submission.