### PR TITLE
fix(a11y): add ARIA tablist/tab/tabpanel roles to PreferencesDialog

### DIFF
--- a/src/components/PreferencesDialog.test.ts
+++ b/src/components/PreferencesDialog.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mount, flushPromises, VueWrapper } from "@vue/test-utils";
+import { setActivePinia, createPinia } from "pinia";
+import PreferencesDialog from "./PreferencesDialog.vue";
+import { usePreferencesStore } from "../stores/preferences";
+import { mockPreferences } from "../mocks/data/preferences";
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(),
+}));
+
+vi.mock("./PrefSourcePopover.vue", () => ({
+  default: { template: "<div />" },
+}));
+
+vi.mock("./ProxySettingsDialog.vue", () => ({
+  default: { template: "<div />" },
+}));
+
+vi.mock("./ExclusiveAppsDialog.vue", () => ({
+  default: {
+    template: "<div />",
+    methods: { prefetch() {} },
+  },
+}));
+
+vi.mock("./TimeRangeSlider.vue", () => ({
+  default: { template: "<div />", props: ["startHour", "endHour", "label"] },
+}));
+
+vi.mock("@vueuse/integrations/useFocusTrap", () => ({
+  useFocusTrap: () => ({ activate: vi.fn(), deactivate: vi.fn() }),
+}));
+
+
+const TAB_NAMES = ["computing", "network", "storage", "schedule", "manager"];
+
+function queryTabs(): HTMLElement[] {
+  return Array.from(document.body.querySelectorAll('[role="tab"]'));
+}
+
+function queryTabPanels(): HTMLElement[] {
+  return Array.from(document.body.querySelectorAll('[role="tabpanel"]'));
+}
+
+function queryVisibleTabPanel(): HTMLElement | null {
+  return queryTabPanels().find((panel) => panel.style.display !== "none") ?? null;
+}
+
+describe("PreferencesDialog ARIA tabs", () => {
+  let wrapper: VueWrapper;
+
+  beforeEach(async () => {
+    document.body.textContent = "";
+    setActivePinia(createPinia());
+
+    const store = usePreferencesStore();
+    store.prefetched = true;
+    store.prefs = { ...mockPreferences };
+
+    wrapper = mount(PreferencesDialog, {
+      props: { open: false },
+      attachTo: document.body,
+    });
+    await wrapper.setProps({ open: true });
+    await flushPromises();
+  });
+
+  afterEach(() => {
+    wrapper.unmount();
+  });
+
+  it("renders tablist with correct role", () => {
+    const tablist = document.body.querySelector('[role="tablist"]');
+    expect(tablist).not.toBeNull();
+    expect(tablist!.getAttribute("aria-label")).toBeTruthy();
+  });
+
+  it("renders 5 tabs with role=tab", () => {
+    const tabs = queryTabs();
+    expect(tabs).toHaveLength(5);
+    tabs.forEach((tab) => {
+      expect(tab.getAttribute("role")).toBe("tab");
+    });
+  });
+
+  it("each tab has id, aria-selected, and aria-controls", () => {
+    const tabs = queryTabs();
+    tabs.forEach((tab, i) => {
+      expect(tab.id).toBe(`tab-${TAB_NAMES[i]}`);
+      expect(tab.getAttribute("aria-controls")).toBe(`tabpanel-${TAB_NAMES[i]}`);
+      expect(tab.getAttribute("aria-selected")).toBe(i === 0 ? "true" : "false");
+    });
+  });
+
+  it("only active tab has tabindex=0, others have -1", () => {
+    const tabs = queryTabs();
+    expect(tabs[0].getAttribute("tabindex")).toBe("0");
+    for (let i = 1; i < tabs.length; i++) {
+      expect(tabs[i].getAttribute("tabindex")).toBe("-1");
+    }
+  });
+
+  it("renders all 5 tabpanels (v-show keeps them in DOM)", () => {
+    const panels = queryTabPanels();
+    expect(panels).toHaveLength(5);
+    panels.forEach((panel, i) => {
+      expect(panel.id).toBe(`tabpanel-${TAB_NAMES[i]}`);
+      expect(panel.getAttribute("aria-labelledby")).toBe(`tab-${TAB_NAMES[i]}`);
+      expect(panel.getAttribute("tabindex")).toBe("0");
+    });
+  });
+
+  it("only the active tabpanel is visible", () => {
+    const visible = queryVisibleTabPanel();
+    expect(visible).not.toBeNull();
+    expect(visible!.id).toBe("tabpanel-computing");
+  });
+
+  it("clicking a tab updates aria-selected and tabpanel", async () => {
+    const tabs = queryTabs();
+    await tabs[1].click();
+    await flushPromises();
+
+    const updatedTabs = queryTabs();
+    expect(updatedTabs[0].getAttribute("aria-selected")).toBe("false");
+    expect(updatedTabs[1].getAttribute("aria-selected")).toBe("true");
+
+    const panel = queryVisibleTabPanel();
+    expect(panel!.id).toBe("tabpanel-network");
+  });
+
+  it("ArrowRight moves to next tab", async () => {
+    const tabs = queryTabs();
+    tabs[0].focus();
+    tabs[0].dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true, cancelable: true }));
+    await flushPromises();
+
+    const updatedTabs = queryTabs();
+    expect(updatedTabs[1].getAttribute("aria-selected")).toBe("true");
+    expect(updatedTabs[0].getAttribute("aria-selected")).toBe("false");
+  });
+
+  it("ArrowLeft wraps from first to last tab", async () => {
+    const tabs = queryTabs();
+    tabs[0].focus();
+    tabs[0].dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowLeft", bubbles: true, cancelable: true }));
+    await flushPromises();
+
+    const updatedTabs = queryTabs();
+    expect(updatedTabs[4].getAttribute("aria-selected")).toBe("true");
+  });
+
+  it("ArrowRight wraps from last to first tab", async () => {
+    const tabs = queryTabs();
+    await tabs[4].click();
+    await flushPromises();
+
+    const lastTab = queryTabs()[4];
+    lastTab.focus();
+    lastTab.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true, cancelable: true }));
+    await flushPromises();
+
+    const updatedTabs = queryTabs();
+    expect(updatedTabs[0].getAttribute("aria-selected")).toBe("true");
+  });
+
+  it("Home moves to first tab", async () => {
+    const tabs = queryTabs();
+    await tabs[2].click();
+    await flushPromises();
+
+    const middleTab = queryTabs()[2];
+    middleTab.focus();
+    middleTab.dispatchEvent(new KeyboardEvent("keydown", { key: "Home", bubbles: true, cancelable: true }));
+    await flushPromises();
+
+    const updatedTabs = queryTabs();
+    expect(updatedTabs[0].getAttribute("aria-selected")).toBe("true");
+  });
+
+  it("End moves to last tab", async () => {
+    const tabs = queryTabs();
+    tabs[0].focus();
+    tabs[0].dispatchEvent(new KeyboardEvent("keydown", { key: "End", bubbles: true, cancelable: true }));
+    await flushPromises();
+
+    const updatedTabs = queryTabs();
+    expect(updatedTabs[4].getAttribute("aria-selected")).toBe("true");
+    expect(queryVisibleTabPanel()!.id).toBe("tabpanel-manager");
+  });
+
+  it("tab panel changes when navigating with arrows", async () => {
+    const tabs = queryTabs();
+    tabs[0].focus();
+
+    // ArrowRight twice -> storage
+    tabs[0].dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true, cancelable: true }));
+    await flushPromises();
+    queryTabs()[1].dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true, cancelable: true }));
+    await flushPromises();
+
+    expect(queryVisibleTabPanel()!.id).toBe("tabpanel-storage");
+  });
+});

--- a/src/components/PreferencesDialog.vue
+++ b/src/components/PreferencesDialog.vue
@@ -17,6 +17,7 @@ import { decimalHoursToTimeString } from "../utils/timeConversion";
 import { useFocusTrap } from "@vueuse/integrations/useFocusTrap";
 
 type TabName = "computing" | "network" | "storage" | "schedule" | "manager";
+const TAB_NAMES: TabName[] = ["computing", "network", "storage", "schedule", "manager"];
 
 const props = withDefaults(defineProps<{ open: boolean; initialTab?: TabName }>(), {
   initialTab: "computing",
@@ -34,6 +35,43 @@ const { t, locale } = useI18n({ useScope: "global" });
 const store = usePreferencesStore();
 const managerStore = useManagerSettingsStore();
 const activeTab = ref<TabName>("computing");
+
+function switchTab(name: TabName) {
+  activeTab.value = name;
+  nextTick(() => {
+    const el = dialogRef.value?.querySelector(`#tab-${name}`) as HTMLElement | null;
+    el?.focus();
+  });
+}
+
+function onTabKeydown(event: KeyboardEvent) {
+  const currentEl = event.currentTarget as HTMLElement | null;
+  const currentId = currentEl?.id ?? "";
+  const fromName = currentId.startsWith("tab-") ? (currentId.slice(4) as TabName) : undefined;
+  const currentTab = fromName && TAB_NAMES.includes(fromName) ? fromName : activeTab.value;
+  const idx = TAB_NAMES.indexOf(currentTab);
+  let target: TabName | undefined;
+
+  switch (event.key) {
+    case "ArrowRight":
+      target = TAB_NAMES[(idx + 1) % TAB_NAMES.length];
+      break;
+    case "ArrowLeft":
+      target = TAB_NAMES[(idx - 1 + TAB_NAMES.length) % TAB_NAMES.length];
+      break;
+    case "Home":
+      target = TAB_NAMES[0];
+      break;
+    case "End":
+      target = TAB_NAMES[TAB_NAMES.length - 1];
+      break;
+    default:
+      return;
+  }
+
+  event.preventDefault();
+  switchTab(target);
+}
 const managerForm = ref({ ...managerStore.settings });
 const form = ref<GlobalPreferences | null>(null);
 const showProxy = ref(false);
@@ -168,35 +206,27 @@ async function save() {
         <div v-if="store.loading && !form" class="prefs-loading">{{ $t('prefs.loading') }}</div>
 
         <template v-else-if="form">
-          <div class="tabs">
+          <div class="tabs" role="tablist" :aria-label="$t('prefs.title')">
             <button
+              v-for="name in TAB_NAMES"
+              :id="`tab-${name}`"
+              :key="name"
+              role="tab"
               class="tab"
-              :class="{ active: activeTab === 'computing' }"
-              @click="activeTab = 'computing'"
+              :class="{ active: activeTab === name }"
+              :aria-selected="activeTab === name"
+              :aria-controls="`tabpanel-${name}`"
+              :tabindex="activeTab === name ? 0 : -1"
+              @click="activeTab = name"
+              @keydown="onTabKeydown"
             >
-              {{ $t('prefs.tabs.computing') }}
+              {{ $t(`prefs.tabs.${name}`) }}
             </button>
-            <button
-              class="tab"
-              :class="{ active: activeTab === 'network' }"
-              @click="activeTab = 'network'"
-            >
-              {{ $t('prefs.tabs.network') }}
-            </button>
-            <button
-              class="tab"
-              :class="{ active: activeTab === 'storage' }"
-              @click="activeTab = 'storage'"
-            >
-              {{ $t('prefs.tabs.storage') }}
-            </button>
-            <button class="tab" :class="{ active: activeTab === 'schedule' }" @click="activeTab = 'schedule'">{{ $t('prefs.tabs.schedule') }}</button>
-            <button class="tab" :class="{ active: activeTab === 'manager' }" @click="activeTab = 'manager'">{{ $t('prefs.tabs.manager') }}</button>
           </div>
 
           <div class="prefs-body">
             <!-- Computing tab -->
-            <div v-if="activeTab === 'computing'" class="prefs-section">
+            <div v-show="activeTab === 'computing'" id="tabpanel-computing" role="tabpanel" aria-labelledby="tab-computing" class="prefs-section" tabindex="0">
               <PrefToggleSwitch
                 v-model="form.run_on_batteries"
                 :label="$t('prefs.computing.runOnBatteries')"
@@ -303,7 +333,7 @@ async function save() {
             </div>
 
             <!-- Network tab -->
-            <div v-if="activeTab === 'network'" class="prefs-section">
+            <div v-show="activeTab === 'network'" id="tabpanel-network" role="tabpanel" aria-labelledby="tab-network" class="prefs-section" tabindex="0">
               <PrefNumericInput
                 v-model="form.max_bytes_sec_down"
                 :label="$t('prefs.network.maxDownload')"
@@ -344,7 +374,7 @@ async function save() {
             </div>
 
             <!-- Storage tab -->
-            <div v-if="activeTab === 'storage'" class="prefs-section">
+            <div v-show="activeTab === 'storage'" id="tabpanel-storage" role="tabpanel" aria-labelledby="tab-storage" class="prefs-section" tabindex="0">
               <PrefNumericInput
                 v-model="form.disk_max_used_gb"
                 :label="$t('prefs.storage.maxDiskGb')"
@@ -379,7 +409,7 @@ async function save() {
             </div>
 
             <!-- Schedule tab -->
-            <div v-if="activeTab === 'schedule'" class="prefs-section">
+            <div v-show="activeTab === 'schedule'" id="tabpanel-schedule" role="tabpanel" aria-labelledby="tab-schedule" class="prefs-section" tabindex="0">
               <p class="section-desc">{{ $t('prefs.schedule.desc') }}</p>
               <div class="schedule-days">
                 <div v-for="(day, i) in dayNames" :key="i" class="schedule-day">
@@ -413,7 +443,7 @@ async function save() {
             </div>
 
             <!-- Manager tab -->
-            <div v-if="activeTab === 'manager'" class="prefs-section">
+            <div v-show="activeTab === 'manager'" id="tabpanel-manager" role="tabpanel" aria-labelledby="tab-manager" class="prefs-section" tabindex="0">
               <div class="manager-row">
                 <span class="manager-label">{{ $t('prefs.manager.appearance') }}</span>
                 <select v-model="managerForm.theme" class="manager-select">
@@ -568,6 +598,12 @@ async function save() {
 
 .tab:hover {
   color: var(--color-text-primary);
+}
+
+.tab:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: -2px;
+  border-radius: var(--radius-sm);
 }
 
 .tab.active {


### PR DESCRIPTION
## Summary

- Add proper WAI-ARIA Tabs pattern to `PreferencesDialog` tab navigation
- Tab container: `role="tablist"` with `aria-label`
- Each tab button: `role="tab"`, `aria-selected`, `aria-controls`, roving `tabindex`
- Each tab panel: `role="tabpanel"`, `aria-labelledby`, `tabindex="0"`
- Arrow Left/Right keyboard navigation with wrapping
- Home/End keys to jump to first/last tab
- `focus-visible` outline on focused tabs
- Refactored 5 hardcoded tab buttons into `v-for` loop (DRY)

Closes #61

## Test plan

- [x] 12 new tests covering ARIA structure and keyboard navigation
- [x] All 323 existing tests still pass
- [x] `vue-tsc --noEmit` passes with 0 errors
- [ ] Manual test: Tab through dialog with VoiceOver, verify "Computing tab, selected, 1 of 5" announcement
- [ ] Manual test: Arrow Left/Right/Home/End navigation between tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)