### PR TITLE
fix(a11y): replace "Active tasks only" button with toggle switch

### DIFF
--- a/src/views/TasksView.test.ts
+++ b/src/views/TasksView.test.ts
@@ -182,6 +182,62 @@ describe("TasksView", () => {
     expect(bar.attributes("aria-valuetext")).toBe("45.60%");
   });
 
+  it("active-only switch has role=switch and aria-checked=false by default", () => {
+    const wrapper = mount(TasksView);
+    const toggle = wrapper.find('[role="switch"]');
+    expect(toggle.exists()).toBe(true);
+    expect(toggle.attributes("aria-checked")).toBe("false");
+  });
+
+  it("clicking active-only switch toggles aria-checked and filters tasks", async () => {
+    const store = useTasksStore();
+    store.tasks = [
+      makeTask({ wu_name: "active_task", active_task: true }),
+      makeTask({ name: "task_002_0", wu_name: "inactive_task", active_task: false, state: 1 }),
+    ];
+
+    const wrapper = mount(TasksView);
+    expect(wrapper.findAll("tbody tr")).toHaveLength(2);
+
+    const toggle = wrapper.find('[role="switch"]');
+    await toggle.trigger("click");
+
+    expect(toggle.attributes("aria-checked")).toBe("true");
+    expect(wrapper.findAll("tbody tr")).toHaveLength(1);
+    expect(wrapper.text()).toContain("active_task");
+    expect(wrapper.text()).not.toContain("inactive_task");
+  });
+
+  it("active-only switch responds to Enter key", async () => {
+    const store = useTasksStore();
+    store.tasks = [
+      makeTask({ active_task: true }),
+      makeTask({ name: "task_002_0", active_task: false, state: 1 }),
+    ];
+
+    const wrapper = mount(TasksView);
+    const toggle = wrapper.find('[role="switch"]');
+    await toggle.trigger("keydown.enter");
+
+    expect(toggle.attributes("aria-checked")).toBe("true");
+    expect(wrapper.findAll("tbody tr")).toHaveLength(1);
+  });
+
+  it("active-only switch responds to Space key", async () => {
+    const store = useTasksStore();
+    store.tasks = [
+      makeTask({ active_task: true }),
+      makeTask({ name: "task_002_0", active_task: false, state: 1 }),
+    ];
+
+    const wrapper = mount(TasksView);
+    const toggle = wrapper.find('[role="switch"]');
+    await toggle.trigger("keydown.space");
+
+    expect(toggle.attributes("aria-checked")).toBe("true");
+    expect(wrapper.findAll("tbody tr")).toHaveLength(1);
+  });
+
   it("opens abort confirmation when Backspace is pressed with selection", async () => {
     const store = useTasksStore();
     store.tasks = [makeTask()];

--- a/src/views/TasksView.vue
+++ b/src/views/TasksView.vue
@@ -391,12 +391,21 @@ function isColVisible(key: string): boolean {
 <template>
   <div class="tasks-view">
     <PageHeader :title="$t('tasks.title')">
-      <button
-        :class="['btn', { 'btn-toggle-active': activeTasksOnly }]"
-        @click="activeTasksOnly = !activeTasksOnly"
-      >
-        {{ $t('tasks.activeOnly') }}
-      </button>
+      <label class="active-filter-toggle" @click.prevent="activeTasksOnly = !activeTasksOnly">
+        <span
+          class="toggle-switch"
+          :class="{ on: activeTasksOnly }"
+          role="switch"
+          :aria-checked="!!activeTasksOnly"
+          aria-labelledby="active-tasks-only-label"
+          tabindex="0"
+          @keydown.enter.prevent="activeTasksOnly = !activeTasksOnly"
+          @keydown.space.prevent="activeTasksOnly = !activeTasksOnly"
+        >
+          <span class="toggle-knob" />
+        </span>
+        <span id="active-tasks-only-label" class="toggle-label">{{ $t('tasks.activeOnly') }}</span>
+      </label>
       <template v-if="hasSelection">
         <button class="btn" :disabled="actionBusy" @click="handleSuspendResume">
           {{ suspendResumeLabel }}
@@ -602,10 +611,49 @@ function isColVisible(key: string): boolean {
   color: var(--color-text-primary);
 }
 
-.btn-toggle-active {
-  background: var(--color-accent-light);
-  color: var(--color-accent);
-  border-color: var(--color-accent);
+.active-filter-toggle {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+  cursor: pointer;
+}
+
+.toggle-switch {
+  width: 36px;
+  height: 20px;
+  border-radius: 10px;
+  background: var(--color-text-tertiary);
+  opacity: 0.4;
+  cursor: pointer;
+  position: relative;
+  flex-shrink: 0;
+  transition: background 0.2s, opacity 0.2s;
+}
+
+.toggle-switch.on {
+  background: var(--color-accent);
+  opacity: 1;
+}
+
+.toggle-knob {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: white;
+  transition: left 0.2s;
+}
+
+.toggle-switch.on .toggle-knob {
+  left: 18px;
+}
+
+.toggle-label {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+  user-select: none;
 }
 
 .btn-columns {


### PR DESCRIPTION
## Summary

- Replace the "Active tasks only" toggle button with a proper `role="switch"` toggle (sliding switch)
- Adds `aria-checked`, keyboard support (Enter/Space), and label
- Visual style matches existing toggle switches in PreferencesDialog
- Addresses item 8 from #63

## Test plan

- [x] 3 new tests: switch role/aria-checked, click toggles + filters, Enter key
- [x] All 327 existing tests pass
- [x] `vue-tsc --noEmit` — 0 errors
- [ ] Manual: verify switch visual appearance in light/dark mode
- [ ] Manual: VoiceOver announces "Active tasks only, switch, off/on"

🤖 Generated with [Claude Code](https://claude.com/claude-code)