### PR TITLE
fix(i18n): replace hardcoded notification strings with i18n keys

### DIFF
--- a/src/composables/useNotifications.test.ts
+++ b/src/composables/useNotifications.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { setActivePinia, createPinia } from "pinia";
 import { useManagerSettingsStore } from "../stores/managerSettings";
+import i18n from "../i18n";
 
 // Mock Tauri notification plugin
 const mockSendNotification = vi.fn();
@@ -57,10 +58,11 @@ describe("useNotifications", () => {
 
       await notifyNewNotices(3);
 
+      const t = i18n.global.t;
       expect(mockSendNotification).toHaveBeenCalledOnce();
       expect(mockSendNotification).toHaveBeenCalledWith({
-        title: "BOINC Notices",
-        body: "There are 3 new notices — click to view",
+        title: t("notifications.newNoticesTitle"),
+        body: t("notifications.newNoticesBody", 3),
       });
     });
 
@@ -70,9 +72,10 @@ describe("useNotifications", () => {
 
       await notifyNewNotices(1);
 
+      const t = i18n.global.t;
       expect(mockSendNotification).toHaveBeenCalledWith({
-        title: "BOINC Notices",
-        body: "There is 1 new notice — click to view",
+        title: t("notifications.newNoticesTitle"),
+        body: t("notifications.newNoticesBody", 1),
       });
     });
 
@@ -166,9 +169,10 @@ describe("useNotifications", () => {
     it("sends connection lost notification", async () => {
       await notifyConnectionLost();
 
+      const t = i18n.global.t;
       expect(mockSendNotification).toHaveBeenCalledWith({
-        title: "BOINC Manager",
-        body: "Lost connection to BOINC client",
+        title: t("notifications.connectionLostTitle"),
+        body: t("notifications.connectionLostBody"),
       });
     });
   });

--- a/src/composables/useNotifications.ts
+++ b/src/composables/useNotifications.ts
@@ -1,4 +1,5 @@
 import { useManagerSettingsStore } from "../stores/managerSettings";
+import i18n from "../i18n";
 
 const LAST_REMINDER_KEY = "boinc-last-reminder";
 
@@ -52,14 +53,17 @@ async function sendNotification(title: string, body: string) {
 export async function notifyNewNotices(count: number) {
   if (count <= 0 || !shouldNotify()) return;
   markNotified();
+  const t = i18n.global.t;
   await sendNotification(
-    "BOINC Notices",
-    count === 1
-      ? "There is 1 new notice — click to view"
-      : `There are ${count} new notices — click to view`,
+    t("notifications.newNoticesTitle"),
+    t("notifications.newNoticesBody", count),
   );
 }
 
 export async function notifyConnectionLost() {
-  await sendNotification("BOINC Manager", "Lost connection to BOINC client");
+  const t = i18n.global.t;
+  await sendNotification(
+    t("notifications.connectionLostTitle"),
+    t("notifications.connectionLostBody"),
+  );
 }

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -187,7 +187,7 @@
     "filterAlerts": "Benutzerhinweise",
     "filterErrors": "Fehler",
     "empty": "Keine Meldungen vorhanden.",
-    "loadingMore": "Ältere Meldungen werden geladen\u2026",
+    "loadingMore": "Ältere Meldungen werden geladen…",
     "col": {
       "time": "Zeit",
       "project": "Projekt",
@@ -671,5 +671,11 @@
     "clear": "Löschen",
     "cancel": "Abbrechen",
     "ok": "OK"
+  },
+  "notifications": {
+    "newNoticesTitle": "Neue Hinweise",
+    "newNoticesBody": "{count} neuer Hinweis | {count} neue Hinweise",
+    "connectionLostTitle": "Verbindung verloren",
+    "connectionLostBody": "Verbindung zum BOINC-Client verloren."
   }
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -187,7 +187,7 @@
     "filterAlerts": "User Alerts",
     "filterErrors": "Errors",
     "empty": "No messages to display.",
-    "loadingMore": "Loading older messages\u2026",
+    "loadingMore": "Loading older messages…",
     "col": {
       "time": "Time",
       "project": "Project",
@@ -671,5 +671,11 @@
     "clear": "Clear",
     "cancel": "Cancel",
     "ok": "OK"
+  },
+  "notifications": {
+    "newNoticesTitle": "New Notices",
+    "newNoticesBody": "{count} new notice | {count} new notices",
+    "connectionLostTitle": "Connection Lost",
+    "connectionLostBody": "Lost connection to the BOINC client."
   }
 }

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -187,7 +187,7 @@
     "filterAlerts": "Alertas de usuario",
     "filterErrors": "Errores",
     "empty": "No hay mensajes para mostrar.",
-    "loadingMore": "Cargando mensajes anteriores\u2026",
+    "loadingMore": "Cargando mensajes anteriores…",
     "col": {
       "time": "Hora",
       "project": "Proyecto",
@@ -671,5 +671,11 @@
     "clear": "Limpiar",
     "cancel": "Cancelar",
     "ok": "Aceptar"
+  },
+  "notifications": {
+    "newNoticesTitle": "Nuevos avisos",
+    "newNoticesBody": "{count} aviso nuevo | {count} avisos nuevos",
+    "connectionLostTitle": "Conexión perdida",
+    "connectionLostBody": "Se perdió la conexión con el cliente BOINC."
   }
 }

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -187,7 +187,7 @@
     "filterAlerts": "Alertes utilisateur",
     "filterErrors": "Erreurs",
     "empty": "Aucun message à afficher.",
-    "loadingMore": "Chargement des anciens messages\u2026",
+    "loadingMore": "Chargement des anciens messages…",
     "col": {
       "time": "Date",
       "project": "Projet",
@@ -671,5 +671,11 @@
     "clear": "Effacer",
     "cancel": "Annuler",
     "ok": "OK"
+  },
+  "notifications": {
+    "newNoticesTitle": "Nouveaux avis",
+    "newNoticesBody": "{count} nouvel avis | {count} nouveaux avis",
+    "connectionLostTitle": "Connexion perdue",
+    "connectionLostBody": "Connexion au client BOINC perdue."
   }
 }

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -187,7 +187,7 @@
     "filterAlerts": "ユーザー警告",
     "filterErrors": "エラー",
     "empty": "表示するメッセージがありません。",
-    "loadingMore": "過去のメッセージを読み込み中\u2026",
+    "loadingMore": "過去のメッセージを読み込み中…",
     "col": {
       "time": "日時",
       "project": "プロジェクト",
@@ -671,5 +671,11 @@
     "clear": "クリア",
     "cancel": "キャンセル",
     "ok": "OK"
+  },
+  "notifications": {
+    "newNoticesTitle": "新しい通知",
+    "newNoticesBody": "{count} 件の新しい通知",
+    "connectionLostTitle": "接続が切断されました",
+    "connectionLostBody": "BOINCクライアントとの接続が失われました。"
   }
 }

--- a/src/i18n/locales/pt_BR.json
+++ b/src/i18n/locales/pt_BR.json
@@ -187,7 +187,7 @@
     "filterAlerts": "Alertas do usuário",
     "filterErrors": "Erros",
     "empty": "Nenhuma mensagem para exibir.",
-    "loadingMore": "Carregando mensagens anteriores\u2026",
+    "loadingMore": "Carregando mensagens anteriores…",
     "col": {
       "time": "Horário",
       "project": "Projeto",
@@ -671,5 +671,11 @@
     "clear": "Limpar",
     "cancel": "Cancelar",
     "ok": "OK"
+  },
+  "notifications": {
+    "newNoticesTitle": "Novos avisos",
+    "newNoticesBody": "{count} novo aviso | {count} novos avisos",
+    "connectionLostTitle": "Conexão perdida",
+    "connectionLostBody": "Conexão com o cliente BOINC perdida."
   }
 }

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -187,7 +187,7 @@
     "filterAlerts": "Оповещения",
     "filterErrors": "Ошибки",
     "empty": "Нет сообщений для отображения.",
-    "loadingMore": "Загрузка старых сообщений\u2026",
+    "loadingMore": "Загрузка старых сообщений…",
     "col": {
       "time": "Время",
       "project": "Проект",
@@ -671,5 +671,11 @@
     "clear": "Очистить",
     "cancel": "Отмена",
     "ok": "OK"
+  },
+  "notifications": {
+    "newNoticesTitle": "Новые уведомления",
+    "newNoticesBody": "{count} новое уведомление | {count} новых уведомления | {count} новых уведомлений",
+    "connectionLostTitle": "Соединение потеряно",
+    "connectionLostBody": "Потеряно соединение с клиентом BOINC."
   }
 }

--- a/src/i18n/locales/zh_CN.json
+++ b/src/i18n/locales/zh_CN.json
@@ -129,11 +129,11 @@
     },
     "resetDialog": {
       "title": "重置项目",
-      "message": "重置\u201c{names}\u201d？该项目的所有任务将会丢失。"
+      "message": "重置“{names}”？该项目的所有任务将会丢失。"
     },
     "detachDialog": {
       "title": "分离项目",
-      "message": "从\u201c{names}\u201d分离？你将停止为该项目贡献计算。"
+      "message": "从“{names}”分离？你将停止为该项目贡献计算。"
     },
     "toast": {
       "updated": "项目已更新",
@@ -187,7 +187,7 @@
     "filterAlerts": "用户警告",
     "filterErrors": "错误",
     "empty": "没有消息可显示。",
-    "loadingMore": "正在加载旧消息\u2026",
+    "loadingMore": "正在加载旧消息…",
     "col": {
       "time": "时间",
       "project": "项目",
@@ -671,5 +671,11 @@
     "clear": "清除",
     "cancel": "取消",
     "ok": "确定"
+  },
+  "notifications": {
+    "newNoticesTitle": "新通知",
+    "newNoticesBody": "{count} 条新通知",
+    "connectionLostTitle": "连接丢失",
+    "connectionLostBody": "与 BOINC 客户端的连接已断开。"
   }
 }


### PR DESCRIPTION
## Summary
- Replace 4 hardcoded English strings in `useNotifications.ts` with `i18n.global.t()` calls
- Add `notifications.*` i18n keys to all 8 locale files (en, de, es, fr, ja, pt_BR, ru, zh_CN)
- Update tests to use translated strings via `i18n.global.t()`
- Russian locale uses proper 3-form pluralization

## Test plan
- [ ] `npx vitest run` — all 332 tests pass
- [ ] Trigger a notification (e.g. new BOINC notice) and verify localized title/body
- [ ] Switch language in preferences and verify notification text matches

🤖 Reviewed with Codex before submission.