### PR TITLE
fix(a11y): add ARIA labels to selects and SVG charts

### DIFF
--- a/src/components/ActivityControls.test.ts
+++ b/src/components/ActivityControls.test.ts
@@ -52,6 +52,15 @@ describe("ActivityControls", () => {
     expect(selects).toHaveLength(3);
   });
 
+  it("each select has an aria-label", () => {
+    const wrapper = mount(ActivityControls);
+    const selects = wrapper.findAll("select");
+
+    selects.forEach((select) => {
+      expect(select.attributes("aria-label")).toBeTruthy();
+    });
+  });
+
   it("displays current mode values", () => {
     const store = useClientStore();
     store.status = {

--- a/src/components/ActivityControls.vue
+++ b/src/components/ActivityControls.vue
@@ -24,7 +24,7 @@ function handleNetworkMode(event: Event) {
   <div class="activity-controls">
     <label class="mode-control">
       <span class="mode-label">{{ $t("activity.cpu") }}</span>
-      <select :value="client.status.task_mode_perm" @change="handleRunMode">
+      <select :value="client.status.task_mode_perm" :aria-label="$t('activity.cpuModeLabel')" @change="handleRunMode">
         <option :value="RUN_MODE.ALWAYS">{{ $t("activity.always") }}</option>
         <option :value="RUN_MODE.AUTO">{{ $t("activity.auto") }}</option>
         <option :value="RUN_MODE.NEVER">{{ $t("activity.suspend") }}</option>
@@ -33,7 +33,7 @@ function handleNetworkMode(event: Event) {
 
     <label class="mode-control">
       <span class="mode-label">{{ $t("activity.gpu") }}</span>
-      <select :value="client.status.gpu_mode_perm" @change="handleGpuMode">
+      <select :value="client.status.gpu_mode_perm" :aria-label="$t('activity.gpuModeLabel')" @change="handleGpuMode">
         <option :value="RUN_MODE.ALWAYS">{{ $t("activity.always") }}</option>
         <option :value="RUN_MODE.AUTO">{{ $t("activity.auto") }}</option>
         <option :value="RUN_MODE.NEVER">{{ $t("activity.suspend") }}</option>
@@ -44,6 +44,7 @@ function handleNetworkMode(event: Event) {
       <span class="mode-label">{{ $t("activity.net") }}</span>
       <select
         :value="client.status.network_mode_perm"
+        :aria-label="$t('activity.netModeLabel')"
         @change="handleNetworkMode"
       >
         <option :value="RUN_MODE.ALWAYS">{{ $t("activity.always") }}</option>

--- a/src/components/StatisticsChart.vue
+++ b/src/components/StatisticsChart.vue
@@ -178,6 +178,8 @@ const activeSeries = computed(() =>
     <h3 v-if="title" class="chart-title">{{ title }}</h3>
     <div ref="containerRef" class="chart-container">
       <svg
+        role="img"
+        :aria-label="(title && title.trim()) || $t('statistics.chartLabel')"
         :width="svgWidth"
         :height="svgHeight"
         class="chart-svg"

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -225,7 +225,8 @@
     "totalDisk": "Gesamtspeicher",
     "boincUsage": "BOINC-Nutzung",
     "freeSpace": "Freier Speicher",
-    "allowed": "Erlaubt"
+    "allowed": "Erlaubt",
+    "chartLabel": "Diagramm zur Festplattennutzung"
   },
   "host": {
     "title": "Rechnerinformationen",
@@ -281,7 +282,8 @@
     "user": "Benutzer",
     "host": "Rechner",
     "totalCredit": "Gesamtguthaben",
-    "avgCredit": "Durchschnittliches Guthaben"
+    "avgCredit": "Durchschnittliches Guthaben",
+    "chartLabel": "Statistikdiagramm"
   },
   "notices": {
     "title": "Nachrichten",
@@ -447,7 +449,10 @@
     "net": "Netz",
     "always": "ständig",
     "auto": "Auto",
-    "suspend": "Anhalten"
+    "suspend": "Anhalten",
+    "cpuModeLabel": "CPU-Modus",
+    "gpuModeLabel": "GPU-Modus",
+    "netModeLabel": "Netzwerkmodus"
   },
   "statusBar": {
     "connected": "Verbunden",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -225,7 +225,8 @@
     "totalDisk": "Total Disk",
     "boincUsage": "BOINC Usage",
     "freeSpace": "Free Space",
-    "allowed": "Allowed"
+    "allowed": "Allowed",
+    "chartLabel": "Disk usage chart"
   },
   "host": {
     "title": "Host Information",
@@ -281,7 +282,8 @@
     "user": "User",
     "host": "Host",
     "totalCredit": "Total Credit",
-    "avgCredit": "Average Credit"
+    "avgCredit": "Average Credit",
+    "chartLabel": "Statistics chart"
   },
   "notices": {
     "title": "Notices",
@@ -447,7 +449,10 @@
     "net": "Net",
     "always": "Always",
     "auto": "Auto",
-    "suspend": "Suspend"
+    "suspend": "Suspend",
+    "cpuModeLabel": "CPU mode",
+    "gpuModeLabel": "GPU mode",
+    "netModeLabel": "Network mode"
   },
   "statusBar": {
     "connected": "Connected",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -225,7 +225,8 @@
     "totalDisk": "Disco total",
     "boincUsage": "Uso de BOINC",
     "freeSpace": "Espacio libre",
-    "allowed": "Permitido"
+    "allowed": "Permitido",
+    "chartLabel": "Gráfico de uso de disco"
   },
   "host": {
     "title": "Información del ordenador",
@@ -281,7 +282,8 @@
     "user": "Usuario",
     "host": "Ordenador",
     "totalCredit": "Crédito total",
-    "avgCredit": "Crédito promedio"
+    "avgCredit": "Crédito promedio",
+    "chartLabel": "Gráfico de estadísticas"
   },
   "notices": {
     "title": "Avisos",
@@ -447,7 +449,10 @@
     "net": "Red",
     "always": "siempre",
     "auto": "Automático",
-    "suspend": "Suspender"
+    "suspend": "Suspender",
+    "cpuModeLabel": "Modo de CPU",
+    "gpuModeLabel": "Modo de GPU",
+    "netModeLabel": "Modo de red"
   },
   "statusBar": {
     "connected": "Conectado",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -225,7 +225,8 @@
     "totalDisk": "Disque total",
     "boincUsage": "Utilisation BOINC",
     "freeSpace": "Espace libre",
-    "allowed": "Autorisé"
+    "allowed": "Autorisé",
+    "chartLabel": "Graphique d'utilisation du disque"
   },
   "host": {
     "title": "Informations sur l'ordinateur",
@@ -281,7 +282,8 @@
     "user": "Utilisateur",
     "host": "Ordinateur",
     "totalCredit": "Crédit total",
-    "avgCredit": "Crédit moyen"
+    "avgCredit": "Crédit moyen",
+    "chartLabel": "Graphique de statistiques"
   },
   "notices": {
     "title": "Notifications",
@@ -447,7 +449,10 @@
     "net": "Réseau",
     "always": "toujours",
     "auto": "Auto",
-    "suspend": "Suspendre"
+    "suspend": "Suspendre",
+    "cpuModeLabel": "Mode CPU",
+    "gpuModeLabel": "Mode GPU",
+    "netModeLabel": "Mode réseau"
   },
   "statusBar": {
     "connected": "Connecté",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -225,7 +225,8 @@
     "totalDisk": "ディスク総容量",
     "boincUsage": "BOINC 使用量",
     "freeSpace": "空き容量",
-    "allowed": "許可量"
+    "allowed": "許可量",
+    "chartLabel": "ディスク使用量チャート"
   },
   "host": {
     "title": "ホスト情報",
@@ -281,7 +282,8 @@
     "user": "参加者",
     "host": "計算機",
     "totalCredit": "合計クレジット",
-    "avgCredit": "平均クレジット"
+    "avgCredit": "平均クレジット",
+    "chartLabel": "統計チャート"
   },
   "notices": {
     "title": "お知らせ",
@@ -447,7 +449,10 @@
     "net": "ネットワーク",
     "always": "常時通知",
     "auto": "自動",
-    "suspend": "一時停止"
+    "suspend": "一時停止",
+    "cpuModeLabel": "CPUモード",
+    "gpuModeLabel": "GPUモード",
+    "netModeLabel": "ネットワークモード"
   },
   "statusBar": {
     "connected": "接続しました",

--- a/src/i18n/locales/pt_BR.json
+++ b/src/i18n/locales/pt_BR.json
@@ -225,7 +225,8 @@
     "totalDisk": "Disco total",
     "boincUsage": "Uso do BOINC",
     "freeSpace": "Espaço livre",
-    "allowed": "Permitido"
+    "allowed": "Permitido",
+    "chartLabel": "Gráfico de uso de disco"
   },
   "host": {
     "title": "Informações do computador",
@@ -281,7 +282,8 @@
     "user": "Usuário",
     "host": "Computador",
     "totalCredit": "Crédito total",
-    "avgCredit": "Crédito médio"
+    "avgCredit": "Crédito médio",
+    "chartLabel": "Gráfico de estatísticas"
   },
   "notices": {
     "title": "Avisos",
@@ -447,7 +449,10 @@
     "net": "Rede",
     "always": "sempre",
     "auto": "Automático",
-    "suspend": "Suspender"
+    "suspend": "Suspender",
+    "cpuModeLabel": "Modo da CPU",
+    "gpuModeLabel": "Modo da GPU",
+    "netModeLabel": "Modo de rede"
   },
   "statusBar": {
     "connected": "Conectado",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -225,7 +225,8 @@
     "totalDisk": "Общий объём диска",
     "boincUsage": "Использовано BOINC",
     "freeSpace": "Свободно",
-    "allowed": "Разрешено"
+    "allowed": "Разрешено",
+    "chartLabel": "Диаграмма использования диска"
   },
   "host": {
     "title": "Информация о компьютере",
@@ -281,7 +282,8 @@
     "user": "Участник",
     "host": "Компьютер (хост)",
     "totalCredit": "Общий кредит",
-    "avgCredit": "Средний кредит"
+    "avgCredit": "Средний кредит",
+    "chartLabel": "График статистики"
   },
   "notices": {
     "title": "Уведомления",
@@ -447,7 +449,10 @@
     "net": "Сеть",
     "always": "всегда",
     "auto": "Авто",
-    "suspend": "Приостановить"
+    "suspend": "Приостановить",
+    "cpuModeLabel": "Режим CPU",
+    "gpuModeLabel": "Режим GPU",
+    "netModeLabel": "Режим сети"
   },
   "statusBar": {
     "connected": "Соединение установлено",

--- a/src/i18n/locales/zh_CN.json
+++ b/src/i18n/locales/zh_CN.json
@@ -225,7 +225,8 @@
     "totalDisk": "磁盘总量",
     "boincUsage": "BOINC 使用量",
     "freeSpace": "可用空间",
-    "allowed": "允许使用"
+    "allowed": "允许使用",
+    "chartLabel": "磁盘使用图表"
   },
   "host": {
     "title": "主机信息",
@@ -281,7 +282,8 @@
     "user": "用户",
     "host": "主机",
     "totalCredit": "总积分",
-    "avgCredit": "平均积分"
+    "avgCredit": "平均积分",
+    "chartLabel": "统计图表"
   },
   "notices": {
     "title": "通知",
@@ -447,7 +449,10 @@
     "net": "网络",
     "always": "总是提醒",
     "auto": "自动",
-    "suspend": "暂停"
+    "suspend": "暂停",
+    "cpuModeLabel": "CPU 模式",
+    "gpuModeLabel": "GPU 模式",
+    "netModeLabel": "网络模式"
   },
   "statusBar": {
     "connected": "已连接",

--- a/src/views/DiskUsageView.test.ts
+++ b/src/views/DiskUsageView.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { mount } from "@vue/test-utils";
+import { mount, flushPromises } from "@vue/test-utils";
 import { setActivePinia, createPinia } from "pinia";
 import DiskUsageView from "./DiskUsageView.vue";
 import { useDiskUsageStore } from "../stores/diskUsage";
@@ -178,6 +178,29 @@ describe("DiskUsageView", () => {
     // Project A: 1000/4000 = 25.0%, Project B: 3000/4000 = 75.0%
     expect(text).toContain("25.0%");
     expect(text).toContain("75.0%");
+  });
+
+  it("doughnut SVG has role='img' and aria-label", async () => {
+    const { getDiskUsage } = await import("../composables/useRpc");
+    const mockData = {
+      projects: [{ master_url: "https://a.org/", disk_usage: 500 }],
+      d_total: 1000,
+      d_free: 500,
+      d_boinc: 500,
+      d_allowed: 1000,
+    };
+    vi.mocked(getDiskUsage).mockResolvedValueOnce(mockData);
+
+    const diskStore = useDiskUsageStore();
+    diskStore.loading = false;
+    diskStore.usage = mockData;
+
+    const wrapper = mount(DiskUsageView);
+    await flushPromises();
+
+    const svg = wrapper.find("svg.doughnut-svg");
+    expect(svg.attributes("role")).toBe("img");
+    expect(svg.attributes("aria-label")).toBeTruthy();
   });
 
   it("renders SVG doughnut chart paths for projects", () => {

--- a/src/views/DiskUsageView.vue
+++ b/src/views/DiskUsageView.vue
@@ -163,6 +163,8 @@ onUnmounted(() => {
           <h3 class="section-title">{{ $t("disk.boincByProject") }}</h3>
           <div class="boinc-chart-card">
             <svg
+              role="img"
+              :aria-label="$t('disk.chartLabel')"
               width="240"
               height="240"
               viewBox="0 0 240 240"


### PR DESCRIPTION
## Summary
- Add `aria-label` to CPU/GPU/Network mode `<select>` elements in ActivityControls
- Add `role="img"` and `aria-label` to SVG charts in StatisticsChart and DiskUsageView
- Add label i18n keys (`disk.chartLabel`, `statistics.chartLabel`, `activity.*ModeLabel`) to all 8 locales
- Add tests verifying ARIA attributes

## Test plan
- [ ] `npx vitest run` — all 332 tests pass
- [ ] Screen reader (VoiceOver) announces select labels on Activity page
- [ ] Screen reader announces chart descriptions on Statistics and Disk Usage pages

🤖 Reviewed with Codex before submission.