### PR TITLE
fix(a11y): add skip-to-content link for keyboard navigation

### DIFF
--- a/src/App.test.ts
+++ b/src/App.test.ts
@@ -206,6 +206,22 @@ describe("App", () => {
     expect(texts).toContain("About");
   });
 
+  it("renders skip-to-content link targeting #main-content", async () => {
+    const router = createTestRouter();
+    await router.push("/tasks");
+    await router.isReady();
+
+    const conn = useConnectionStore();
+    conn.state = CONNECTION_STATE.CONNECTED;
+
+    const wrapper = await mountApp(router);
+
+    const skipLink = wrapper.find("a.skip-link");
+    expect(skipLink.exists()).toBe(true);
+    expect(skipLink.attributes("href")).toBe("#main-content");
+    expect(wrapper.find("#main-content").exists()).toBe(true);
+  });
+
   it("prevents Backspace on non-editable targets", async () => {
     const router = createTestRouter();
     await router.push("/tasks");

--- a/src/App.vue
+++ b/src/App.vue
@@ -383,6 +383,7 @@ watch(
     </div>
   </div>
   <div v-else class="app" :class="{ 'has-sidebar': hasSidebar }">
+    <a href="#main-content" class="skip-link">{{ $t("app.skipToContent") }}</a>
     <button
       v-if="hasSidebar"
       class="hamburger-btn"
@@ -539,7 +540,7 @@ watch(
         </div>
       </div>
     </aside>
-    <main class="main-content" :style="{ '--status-bar-offset': hasStatusBar ? '28px' : '0px' }">
+    <main id="main-content" class="main-content" :style="{ '--status-bar-offset': hasStatusBar ? '28px' : '0px' }">
       <UpdateBanner v-if="updateAvailable && !dismissed" />
       <router-view />
     </main>
@@ -992,6 +993,27 @@ select {
   to {
     transform: rotate(360deg);
   }
+}
+
+/* ── Skip-to-content link (visible only on keyboard focus) ──── */
+
+.skip-link {
+  position: absolute;
+  top: -100%;
+  left: 16px;
+  z-index: 1000;
+  padding: 8px 16px;
+  background: var(--color-bg-primary);
+  color: var(--color-text-primary);
+  border: 2px solid var(--color-border);
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-sm);
+  text-decoration: none;
+  transition: top 0.15s ease;
+}
+
+.skip-link:focus {
+  top: 8px;
 }
 
 /* ── Hamburger button (mobile only) ─────────────────────────── */

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -6,7 +6,8 @@
       "startingBoinc": "BOINC wird gestartet, dies kann etwas dauern...",
       "boincStarted": "BOINC gestartet, Verbindung wird hergestellt...",
       "cancel": "Abbrechen"
-    }
+    },
+    "skipToContent": "Zum Inhalt springen"
   },
   "sidebar": {
     "computing": "Berechnung läuft",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -6,7 +6,8 @@
       "startingBoinc": "Starting BOINC, this may take a while...",
       "boincStarted": "BOINC started, connecting...",
       "cancel": "Cancel"
-    }
+    },
+    "skipToContent": "Skip to content"
   },
   "sidebar": {
     "computing": "Computing",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -6,7 +6,8 @@
       "startingBoinc": "Iniciando BOINC, esto puede tardar un momento...",
       "boincStarted": "BOINC iniciado, conectando...",
       "cancel": "Cancelar"
-    }
+    },
+    "skipToContent": "Saltar al contenido"
   },
   "sidebar": {
     "computing": "Procesando",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -6,7 +6,8 @@
       "startingBoinc": "Démarrage de BOINC, cela peut prendre un moment...",
       "boincStarted": "BOINC démarré, connexion en cours...",
       "cancel": "Annuler"
-    }
+    },
+    "skipToContent": "Aller au contenu"
   },
   "sidebar": {
     "computing": "Calculs en cours",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -6,7 +6,8 @@
       "startingBoinc": "BOINC を起動中です。しばらくお待ちください...",
       "boincStarted": "BOINC が起動しました。接続中...",
       "cancel": "キャンセル"
-    }
+    },
+    "skipToContent": "コンテンツへスキップ"
   },
   "sidebar": {
     "computing": "計算",

--- a/src/i18n/locales/pt_BR.json
+++ b/src/i18n/locales/pt_BR.json
@@ -6,7 +6,8 @@
       "startingBoinc": "Iniciando BOINC, isso pode demorar um pouco...",
       "boincStarted": "BOINC iniciado, conectando...",
       "cancel": "Cancelar"
-    }
+    },
+    "skipToContent": "Pular para o conteúdo"
   },
   "sidebar": {
     "computing": "Computação",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -6,7 +6,8 @@
       "startingBoinc": "Запуск BOINC, это может занять некоторое время...",
       "boincStarted": "BOINC запущен, подключение...",
       "cancel": "Отмена"
-    }
+    },
+    "skipToContent": "Перейти к содержимому"
   },
   "sidebar": {
     "computing": "Вычисления",

--- a/src/i18n/locales/zh_CN.json
+++ b/src/i18n/locales/zh_CN.json
@@ -6,7 +6,8 @@
       "startingBoinc": "正在启动 BOINC，请稍候...",
       "boincStarted": "BOINC 已启动，正在连接...",
       "cancel": "取消"
-    }
+    },
+    "skipToContent": "跳转到内容"
   },
   "sidebar": {
     "computing": "正在计算",


### PR DESCRIPTION
## Summary
- Add a visually hidden skip-to-content link that becomes visible on keyboard focus (Tab), allowing keyboard users to jump directly to main content (WCAG 2.4.1)
- Add `id="main-content"` anchor on `<main>` element
- Add `app.skipToContent` i18n key across all 8 locales
- Add test verifying skip-link renders with correct `href`

## Test plan
- [x] `npx vitest run` — 412+ tests pass
- [ ] Tab from browser address bar → skip-link appears, Enter → focus moves to main content
- [ ] Verify translations render correctly for non-EN locales

🤖 Generated with [Claude Code](https://claude.com/claude-code)