### PR TITLE
fix(a11y): add focus-visible styles for keyboard navigation

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -452,6 +452,17 @@ body {
   -moz-osx-font-smoothing: grayscale;
 }
 
+/* Global focus-visible outline for keyboard navigation (WCAG 2.4.7) */
+:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
+/* Remove default focus for mouse users */
+:focus:not(:focus-visible) {
+  outline: none;
+}
+
 /* Global button styles */
 .btn {
   padding: 6px 14px;

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -29,6 +29,9 @@
   --color-toast-error-bg: #991b1b;
   --color-toast-error-text: #fee2e2;
 
+  /* Focus */
+  --color-focus-ring: #3b82f6;
+
   /* Radius */
   --radius-sm: 6px;
   --radius-md: 8px;
@@ -113,6 +116,9 @@
     --color-toast-success-text: #d1fae5;
     --color-toast-error-bg: #7f1d1d;
     --color-toast-error-text: #fee2e2;
+
+    /* Focus */
+    --color-focus-ring: #60a5fa;
 
     /* Shadows */
     --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.3);


### PR DESCRIPTION
## Summary
- Add `--color-focus-ring` CSS custom property to design tokens (light: `#3b82f6`, dark: `#60a5fa`)
- Add global `:focus-visible` outline style (2px solid, 2px offset) for all interactive elements (WCAG 2.4.7)
- Remove default outline on mouse-click focus via `:focus:not(:focus-visible)`

## Test plan
- [x] `npx vitest run` — all tests pass
- [ ] Tab through UI elements → blue focus ring visible on each
- [ ] Click elements with mouse → no focus ring shown
- [ ] Verify in dark mode → lighter blue ring

🤖 Generated with [Claude Code](https://claude.com/claude-code)