### PR TITLE
fix(a11y): add ARIA roles to StatusBar and ToastContainer

### DIFF
--- a/src/components/StatusBar.test.ts
+++ b/src/components/StatusBar.test.ts
@@ -67,4 +67,25 @@ describe("StatusBar", () => {
     const wrapper = mount(StatusBar);
     expect(wrapper.find(".about-btn").exists()).toBe(true);
   });
+
+  it("has contentinfo role on status bar", () => {
+    const conn = useConnectionStore();
+    conn.state = CONNECTION_STATE.CONNECTED;
+    const wrapper = mount(StatusBar);
+    expect(wrapper.find(".status-bar").attributes("role")).toBe("contentinfo");
+  });
+
+  it("about button has aria-label", () => {
+    const conn = useConnectionStore();
+    conn.state = CONNECTION_STATE.CONNECTED;
+    const wrapper = mount(StatusBar);
+    expect(wrapper.find(".about-btn").attributes("aria-label")).toBe("About");
+  });
+
+  it("status dot is hidden from screen readers", () => {
+    const conn = useConnectionStore();
+    conn.state = CONNECTION_STATE.CONNECTED;
+    const wrapper = mount(StatusBar);
+    expect(wrapper.find(".status-dot").attributes("aria-hidden")).toBe("true");
+  });
 });

--- a/src/components/StatusBar.vue
+++ b/src/components/StatusBar.vue
@@ -44,9 +44,9 @@ const statusText = computed(() => {
 </script>
 
 <template>
-  <div class="status-bar">
+  <div class="status-bar" role="contentinfo">
     <div class="status-section">
-      <span class="status-dot" :class="statusDotClass" />
+      <span class="status-dot" :class="statusDotClass" aria-hidden="true" />
       <span>{{ statusText }}</span>
     </div>
 
@@ -60,7 +60,7 @@ const statusText = computed(() => {
     </div>
 
     <Tooltip :text="$t('statusBar.about')" placement="top">
-      <button class="about-btn" @click="emit('show-about')">
+      <button class="about-btn" :aria-label="$t('statusBar.about')" @click="emit('show-about')">
         <svg viewBox="0 0 20 20" fill="currentColor" width="14" height="14">
           <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd" />
         </svg>

--- a/src/components/ToastContainer.vue
+++ b/src/components/ToastContainer.vue
@@ -11,10 +11,11 @@ const toast = useToastStore();
         <div
           v-for="t in toast.toasts"
           :key="t.id"
+          role="status"
           :class="['toast', `toast-${t.type}`]"
           @click="toast.dismiss(t.id)"
         >
-          <span class="toast-icon">
+          <span class="toast-icon" aria-hidden="true">
             <template v-if="t.type === 'success'">&#x2713;</template>
             <template v-else-if="t.type === 'error'">&#x2717;</template>
             <template v-else>&#x2139;</template>


### PR DESCRIPTION
## Summary
- StatusBar: add `role="contentinfo"`, `aria-label` on About button, `aria-hidden` on decorative status dot
- ToastContainer: add `role="status"` on each toast for live-region announcements, `aria-hidden` on decorative icons
- Add 3 tests for StatusBar ARIA attributes

## Test plan
- [x] `npx vitest run` — all tests pass
- [ ] Screen reader announces toast notifications as they appear
- [ ] About button read as "About" (not just icon)
- [ ] Status dot not announced by screen reader

🤖 Generated with [Claude Code](https://claude.com/claude-code)