### PR TITLE
fix(connection): unify SelectComputerDialog with useConnectionStore

### DIFF
--- a/src/App.test.ts
+++ b/src/App.test.ts
@@ -5,6 +5,7 @@ import { createRouter, createMemoryHistory } from "vue-router";
 import App from "./App.vue";
 import { useConnectionStore } from "./stores/connection";
 import { CONNECTION_STATE } from "./types/boinc";
+import { connectLocal } from "./composables/useRpc";
 
 vi.mock("@tauri-apps/api/core", () => ({
   invoke: vi.fn().mockResolvedValue(undefined),
@@ -301,6 +302,45 @@ describe("App", () => {
     document.body.dispatchEvent(event);
 
     expect(spy).toHaveBeenCalled();
+  });
+
+  it("navigates to /tasks when SelectComputerDialog emits connected", async () => {
+    // Make autoConnect fail so it stays on "/"
+    vi.mocked(connectLocal).mockRejectedValueOnce(new Error("no client"));
+
+    const router = createTestRouter();
+    await router.push("/");
+    await router.isReady();
+
+    const selectComputerStub = { template: "<div />", name: "SelectComputerDialog" };
+    const wrapper = mount(App, {
+      global: {
+        plugins: [router],
+        stubs: {
+          ActivityControls: stubComponent,
+          PreferencesDialog: stubComponent,
+          AboutDialog: stubComponent,
+          SelectComputerDialog: selectComputerStub,
+          ManagerOptionsDialog: stubComponent,
+          ExitConfirmDialog: stubComponent,
+          StatusBar: stubComponent,
+          ToastContainer: stubComponent,
+          UpdateBanner: stubComponent,
+        },
+      },
+    });
+    await flushPromises();
+
+    // autoConnect failed — still on "/"
+    expect(router.currentRoute.value.path).toBe("/");
+
+    const dialog = wrapper.findComponent({ name: "SelectComputerDialog" });
+    expect(dialog.exists()).toBe(true);
+
+    dialog.vm.$emit("connected");
+    await flushPromises();
+
+    expect(router.currentRoute.value.path).toBe("/tasks");
   });
 
   it("allows Backspace inside text input", async () => {

--- a/src/components/SelectComputerDialog.vue
+++ b/src/components/SelectComputerDialog.vue
@@ -66,7 +66,8 @@ async function doConnectLocal() {
       error.value = connection.error ?? t("selectComputer.connectionFailed");
     }
   } catch (e) {
-    error.value = e instanceof Error ? e.message : String(e);
+    console.error(e);
+    error.value = t("selectComputer.connectionFailed");
   } finally {
     connecting.value = false;
   }


### PR DESCRIPTION
## Summary
- Refactor `SelectComputerDialog` to use `useConnectionStore` instead of raw `connect`/`connectLocal` RPC calls
- Add `connected` event so `App.vue` can start polling and navigate on successful connection
- Add `connectionFailed` i18n key across all 8 locales for user-facing error feedback

## Test plan
- [ ] Open Select Computer dialog → connect to remote host → verify polling starts and navigates to `/tasks`
- [ ] Open Select Computer dialog → connect locally → verify same behavior
- [ ] Simulate connection failure → verify localized error message appears
- [ ] Verify dialog focus trap and keyboard navigation still work

Reviewed with Codex before submission.