### PR TITLE
fix(stores): reset Event Log and Notices session state on reconnect

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -144,6 +144,8 @@ const {
 // ── Auto-connect to local BOINC client on startup ───────────────
 
 function startAllPolling() {
+  messagesStore.resetSessionState();
+  noticesStore.resetSessionState();
   tasksStore.startPolling();
   projectsStore.startPolling();
   transfersStore.startPolling();

--- a/src/stores/messages.test.ts
+++ b/src/stores/messages.test.ts
@@ -237,6 +237,77 @@ describe("useMessagesStore", () => {
     expect(store.filteredMessages).toHaveLength(3);
   });
 
+  it("resetSessionState clears data and stops polling", async () => {
+    const all = Array.from({ length: 10 }, (_, i) => makeMessage(i + 1));
+    stubRpc(10, all);
+
+    const store = useMessagesStore();
+    store.startPolling(1000);
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(store.messages.length).toBeGreaterThan(0);
+
+    store.resetSessionState();
+
+    expect(store.messages).toEqual([]);
+    expect(store.loading).toBe(false);
+    expect(store.error).toBeNull();
+    expect(store.hasMore).toBe(true);
+    expect(store.loadingMore).toBe(false);
+
+    // Polling should be stopped
+    const callsAfterReset = mockInvoke.mock.calls.length;
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(mockInvoke.mock.calls.length).toBe(callsAfterReset);
+  });
+
+  it("resetSessionState invalidates in-flight fetches", async () => {
+    let resolveRpc: (value: unknown) => void;
+    mockInvoke.mockImplementationOnce(
+      () => new Promise((resolve) => { resolveRpc = resolve; }),
+    );
+
+    const store = useMessagesStore();
+    const fetchPromise = store.fetchMessages();
+
+    // Reset while fetch is still pending
+    store.resetSessionState();
+
+    // Resolve the stale fetch — its result should be discarded
+    resolveRpc!(10);
+    await fetchPromise;
+
+    expect(store.messages).toEqual([]);
+  });
+
+  it("resetSessionState resets initialized flag so next fetch starts fresh", async () => {
+    const all = Array.from({ length: 10 }, (_, i) => makeMessage(i + 1));
+    stubRpc(10, all);
+
+    const store = useMessagesStore();
+    await store.fetchMessages(); // initial fetch
+    expect(store.messages).toHaveLength(10);
+
+    store.resetSessionState();
+
+    // After reset, next fetch should do the initial windowing again (get_message_count)
+    const newMessages = Array.from({ length: 5 }, (_, i) => makeMessage(i + 1));
+    stubRpc(5, newMessages);
+
+    await store.fetchMessages();
+    expect(store.messages).toHaveLength(5);
+    expect(store.messages[0].seqno).toBe(1);
+  });
+
+  it("resetSessionState preserves searchText", async () => {
+    const store = useMessagesStore();
+    store.searchText = "important";
+
+    store.resetSessionState();
+
+    expect(store.searchText).toBe("important");
+  });
+
   it("polling starts and stops correctly", async () => {
     const all = Array.from({ length: 5 }, (_, i) => makeMessage(i + 1));
     stubRpc(5, all);

--- a/src/stores/messages.ts
+++ b/src/stores/messages.ts
@@ -17,6 +17,7 @@ export const useMessagesStore = defineStore("messages", () => {
   const loadingMore = ref(false);
   let pollTimer: ReturnType<typeof setInterval> | null = null;
   let initialized = false;
+  let generation = 0;
 
   const filteredMessages = computed(() => {
     let result = messages.value;
@@ -34,11 +35,14 @@ export const useMessagesStore = defineStore("messages", () => {
   async function fetchMessages() {
     loading.value = true;
     error.value = null;
+    const fetchGeneration = generation;
     try {
       if (!initialized) {
         const count = await getMessageCount();
+        if (fetchGeneration !== generation) return;
         const startSeqno = Math.max(0, count - PAGE_SIZE);
         const initial = await getMessages(startSeqno);
+        if (fetchGeneration !== generation) return;
         if (initial.length > 0) {
           messages.value = initial;
           lastSeqno.value = Math.max(...initial.map((m) => m.seqno));
@@ -47,17 +51,21 @@ export const useMessagesStore = defineStore("messages", () => {
         initialized = true;
       } else {
         const newMessages = await getMessages(lastSeqno.value);
+        if (fetchGeneration !== generation) return;
         if (newMessages.length > 0) {
           messages.value = [...messages.value, ...newMessages];
           lastSeqno.value = Math.max(...newMessages.map((m) => m.seqno));
         }
       }
     } catch (e) {
+      if (fetchGeneration !== generation) return;
       error.value = e instanceof Error ? e.message : String(e);
       const connection = useConnectionStore();
       connection.handleConnectionError();
     } finally {
-      loading.value = false;
+      if (fetchGeneration === generation) {
+        loading.value = false;
+      }
     }
   }
 
@@ -66,6 +74,7 @@ export const useMessagesStore = defineStore("messages", () => {
       return;
 
     loadingMore.value = true;
+    const fetchGeneration = generation;
     try {
       const oldestSeqno = Math.min(...messages.value.map((m) => m.seqno));
       if (oldestSeqno <= 0) {
@@ -78,6 +87,7 @@ export const useMessagesStore = defineStore("messages", () => {
       // and filter client-side to keep only the needed slice.
       const startSeqno = Math.max(0, oldestSeqno - PAGE_SIZE - 1);
       const older = await getMessages(startSeqno);
+      if (fetchGeneration !== generation) return;
       const filtered = older.filter((m) => m.seqno < oldestSeqno);
 
       if (filtered.length > 0) {
@@ -86,11 +96,14 @@ export const useMessagesStore = defineStore("messages", () => {
 
       hasMore.value = startSeqno > 0 && filtered.length > 0;
     } catch (e) {
+      if (fetchGeneration !== generation) return;
       error.value = e instanceof Error ? e.message : String(e);
       const connection = useConnectionStore();
       connection.handleConnectionError();
     } finally {
-      loadingMore.value = false;
+      if (fetchGeneration === generation) {
+        loadingMore.value = false;
+      }
     }
   }
 
@@ -107,6 +120,18 @@ export const useMessagesStore = defineStore("messages", () => {
     }
   }
 
+  function resetSessionState() {
+    stopPolling();
+    generation++;
+    messages.value = [];
+    lastSeqno.value = 0;
+    hasMore.value = true;
+    loadingMore.value = false;
+    loading.value = false;
+    error.value = null;
+    initialized = false;
+  }
+
   return {
     messages,
     loading,
@@ -119,5 +144,6 @@ export const useMessagesStore = defineStore("messages", () => {
     fetchOlderMessages,
     startPolling,
     stopPolling,
+    resetSessionState,
   };
 });

--- a/src/stores/notices.test.ts
+++ b/src/stores/notices.test.ts
@@ -104,6 +104,99 @@ describe("useNoticesStore", () => {
     expect(spy).toHaveBeenCalledOnce();
   });
 
+  it("resetSessionState clears data and stops polling", async () => {
+    mockGetNotices.mockResolvedValueOnce([makeNotice(1), makeNotice(2)]);
+    const store = useNoticesStore();
+    store.startPolling(1000);
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(store.notices.length).toBeGreaterThan(0);
+
+    store.resetSessionState();
+
+    expect(store.notices).toEqual([]);
+    expect(store.loading).toBe(false);
+    expect(store.error).toBeNull();
+
+    // Polling should be stopped — no further fetches
+    const callsAfterReset = mockGetNotices.mock.calls.length;
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(mockGetNotices.mock.calls.length).toBe(callsAfterReset);
+  });
+
+  it("resetSessionState invalidates in-flight fetches", async () => {
+    let resolveRpc: (value: Notice[]) => void;
+    mockGetNotices.mockImplementationOnce(
+      () => new Promise((resolve) => { resolveRpc = resolve; }),
+    );
+
+    const store = useNoticesStore();
+    const fetchPromise = store.fetchNotices();
+
+    // Reset while fetch is still pending
+    store.resetSessionState();
+
+    // Resolve the stale fetch — its result should be discarded
+    resolveRpc!([makeNotice(1)]);
+    await fetchPromise;
+
+    expect(store.notices).toEqual([]);
+  });
+
+  it("resetSessionState suppresses notification on first fetch after reset", async () => {
+    mockGetNotices.mockResolvedValueOnce([makeNotice(1)]);
+    const store = useNoticesStore();
+    await store.fetchNotices();
+    expect(mockNotify).toHaveBeenCalledTimes(1);
+
+    store.resetSessionState();
+    mockNotify.mockClear();
+
+    // First fetch after reset: catch-up, no notification
+    mockGetNotices.mockResolvedValueOnce([makeNotice(5), makeNotice(6)]);
+    await store.fetchNotices();
+    expect(store.notices).toHaveLength(2);
+    expect(mockNotify).not.toHaveBeenCalled();
+
+    // Second fetch: new notices, should notify
+    mockGetNotices.mockResolvedValueOnce([makeNotice(7)]);
+    await store.fetchNotices();
+    expect(mockNotify).toHaveBeenCalledWith(1);
+  });
+
+  it("resetSessionState clears catchingUp even when first fetch returns empty", async () => {
+    const store = useNoticesStore();
+    store.resetSessionState();
+    mockNotify.mockClear();
+
+    // First fetch after reset returns empty
+    mockGetNotices.mockResolvedValueOnce([]);
+    await store.fetchNotices();
+    expect(mockNotify).not.toHaveBeenCalled();
+
+    // Second fetch returns notices — should notify normally
+    mockGetNotices.mockResolvedValueOnce([makeNotice(1)]);
+    await store.fetchNotices();
+    expect(mockNotify).toHaveBeenCalledWith(1);
+  });
+
+  it("resetSessionState allows re-fetching from scratch", async () => {
+    mockGetNotices.mockResolvedValueOnce([makeNotice(1)]);
+    const store = useNoticesStore();
+    await store.fetchNotices();
+    expect(store.notices).toHaveLength(1);
+
+    store.resetSessionState();
+
+    mockGetNotices.mockResolvedValueOnce([makeNotice(10)]);
+    await store.fetchNotices();
+
+    // Should have fetched from seqno 0 (reset) and only contain new data
+    expect(mockGetNotices).toHaveBeenLastCalledWith(0);
+    expect(store.notices).toHaveLength(1);
+    expect(store.notices[0].seqno).toBe(10);
+  });
+
   it("polls and stops", async () => {
     mockGetNotices.mockResolvedValue([]);
     const store = useNoticesStore();

--- a/src/stores/notices.ts
+++ b/src/stores/notices.ts
@@ -13,23 +13,33 @@ export const useNoticesStore = defineStore("notices", () => {
   const error = ref<string | null>(null);
   const lastSeqno = ref(0);
   let pollTimer: ReturnType<typeof setInterval> | null = null;
+  let generation = 0;
+  let catchingUp = false;
 
   async function fetchNotices() {
     loading.value = true;
     error.value = null;
+    const fetchGeneration = generation;
     try {
       const newNotices = await getNotices(lastSeqno.value);
+      if (fetchGeneration !== generation) return;
       if (newNotices.length > 0) {
         notices.value = [...notices.value, ...newNotices];
         lastSeqno.value = Math.max(...newNotices.map((n) => n.seqno));
-        notifyNewNotices(newNotices.length);
+        if (!catchingUp) {
+          notifyNewNotices(newNotices.length);
+        }
       }
+      catchingUp = false;
     } catch (e) {
+      if (fetchGeneration !== generation) return;
       error.value = e instanceof Error ? e.message : String(e);
       const connection = useConnectionStore();
       connection.handleConnectionError();
     } finally {
-      loading.value = false;
+      if (fetchGeneration === generation) {
+        loading.value = false;
+      }
     }
   }
 
@@ -46,5 +56,15 @@ export const useNoticesStore = defineStore("notices", () => {
     }
   }
 
-  return { notices, loading, error, fetchNotices, startPolling, stopPolling };
+  function resetSessionState() {
+    stopPolling();
+    generation++;
+    notices.value = [];
+    lastSeqno.value = 0;
+    loading.value = false;
+    error.value = null;
+    catchingUp = true;
+  }
+
+  return { notices, loading, error, fetchNotices, startPolling, stopPolling, resetSessionState };
 });

--- a/src/views/ConnectView.vue
+++ b/src/views/ConnectView.vue
@@ -143,6 +143,8 @@ const connectionLabel = computed(() => {
 });
 
 function startAllPolling() {
+  messages.resetSessionState();
+  notices.resetSessionState();
   tasks.startPolling();
   projects.startPolling();
   transfers.startPolling();


### PR DESCRIPTION
## Summary
- Add `resetSessionState()` to messages and notices stores — clears session data (messages/notices, seqno, error) while preserving user settings (searchText)
- Call `resetSessionState()` before `startAllPolling()` on every new connection (App.vue, ConnectView.vue) to prevent stale data from a previous host
- Use a generation counter to invalidate in-flight RPC responses that belong to a previous session
- Suppress notifications for the first batch of notices after reconnect (catch-up, not new)

## Test plan
- [ ] Connect to a local BOINC client, navigate to Event Log and Notices — data loads normally
- [ ] Switch to a different host via Select Computer dialog — Event Log and Notices show fresh data from the new host, no stale entries
- [ ] Disconnect and reconnect — stores start fresh, no duplicate or mixed-host data
- [ ] Verify searchText in Event Log persists across reconnects
- [ ] Run `pnpm test` — all 441 tests pass

Reviewed with Codex before submission.