### PR TITLE
fix(messages): make Copy All / Copy Selected respect active type filter

### DIFF
--- a/src/views/MessagesView.test.ts
+++ b/src/views/MessagesView.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeAll, beforeEach, afterAll } from "vitest";
 import { mount } from "@vue/test-utils";
 import { setActivePinia, createPinia } from "pinia";
 import MessagesView from "./MessagesView.vue";
@@ -21,10 +21,33 @@ function makeMessage(overrides: Partial<Message> = {}): Message {
   };
 }
 
+const writeText = vi.fn().mockResolvedValue(undefined);
+
 describe("MessagesView", () => {
+  let originalClipboard: PropertyDescriptor | undefined;
+
+  beforeAll(() => {
+    originalClipboard = Object.getOwnPropertyDescriptor(navigator, "clipboard");
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterAll(() => {
+    if (originalClipboard) {
+      Object.defineProperty(navigator, "clipboard", originalClipboard);
+    } else {
+      // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+      delete (navigator as unknown as Record<string, unknown>)["clipboard"];
+    }
+  });
+
   beforeEach(() => {
     setActivePinia(createPinia());
     localStorage.clear();
+    writeText.mockClear();
   });
 
   it("renders messages in chronological order by default (oldest first)", () => {
@@ -124,5 +147,102 @@ describe("MessagesView", () => {
     expect(labels).toContain("Info");
     expect(labels).toContain("Alert");
     expect(labels).toContain("Error");
+  });
+
+  it("Copy All respects active type filter", async () => {
+    const store = useMessagesStore();
+    store.messages = [
+      makeMessage({
+        seqno: 1,
+        priority: MSG_PRIORITY.INFO,
+        body: "Info msg",
+        timestamp: 1000,
+      }),
+      makeMessage({
+        seqno: 2,
+        priority: MSG_PRIORITY.USER_ALERT,
+        body: "Alert msg",
+        timestamp: 2000,
+      }),
+      makeMessage({
+        seqno: 3,
+        priority: MSG_PRIORITY.INTERNAL_ERROR,
+        body: "Error msg",
+        timestamp: 3000,
+      }),
+    ];
+
+    const wrapper = mount(MessagesView);
+
+    // Switch to "Errors" filter
+    const errorsBtn = wrapper
+      .findAll(".segment")
+      .find((b) => b.text() === "Errors");
+    expect(errorsBtn).toBeTruthy();
+    await errorsBtn!.trigger("click");
+
+    // Click Copy All (no selection)
+    const copyBtn = wrapper
+      .findAll(".btn")
+      .find((b) => b.text().includes("Copy"));
+    expect(copyBtn).toBeTruthy();
+    await copyBtn!.trigger("click");
+
+    expect(writeText).toHaveBeenCalledTimes(1);
+    const copied = writeText.mock.calls[0][0] as string;
+    expect(copied).toContain("Error msg");
+    expect(copied).not.toContain("Info msg");
+    expect(copied).not.toContain("Alert msg");
+  });
+
+  it("Copy Selected only copies selected rows within filtered set", async () => {
+    const store = useMessagesStore();
+    store.messages = [
+      makeMessage({
+        seqno: 1,
+        priority: MSG_PRIORITY.INTERNAL_ERROR,
+        body: "Error one",
+        timestamp: 1000,
+      }),
+      makeMessage({
+        seqno: 2,
+        priority: MSG_PRIORITY.INTERNAL_ERROR,
+        body: "Error two",
+        timestamp: 2000,
+      }),
+      makeMessage({
+        seqno: 3,
+        priority: MSG_PRIORITY.INFO,
+        body: "Info msg",
+        timestamp: 3000,
+      }),
+    ];
+
+    const wrapper = mount(MessagesView);
+
+    // Switch to "Errors" filter
+    const errorsBtn = wrapper
+      .findAll(".segment")
+      .find((b) => b.text() === "Errors");
+    expect(errorsBtn).toBeTruthy();
+    await errorsBtn!.trigger("click");
+
+    // Select first error row by clicking it
+    const rows = wrapper.findAll("tbody tr");
+    expect(rows).toHaveLength(2);
+    await rows[0].trigger("click");
+
+    // Click Copy Selected
+    const copyBtn = wrapper
+      .findAll(".btn")
+      .find((b) => b.text().includes("Copy"));
+    expect(copyBtn).toBeTruthy();
+    await copyBtn!.trigger("click");
+
+    expect(writeText).toHaveBeenCalledTimes(1);
+    const copied = writeText.mock.calls[0][0] as string;
+    expect(copied).toContain("Error one");
+    expect(copied).not.toContain("Error two");
+    expect(copied).not.toContain("Info msg");
   });
 });

--- a/src/views/MessagesView.vue
+++ b/src/views/MessagesView.vue
@@ -170,11 +170,19 @@ function formatMessage(m: {
   return `[${formatTimestamp(m.timestamp)}] ${m.project ? m.project + ": " : ""}${m.body}`;
 }
 
+const visibleSelectedCount = computed(() => {
+  if (selectedSeqnos.value.size === 0) return 0;
+  return filteredByType.value.filter((m) =>
+    selectedSeqnos.value.has(m.seqno),
+  ).length;
+});
+
 async function copySelectedToClipboard() {
-  const msgs =
-    selectedSeqnos.value.size > 0
-      ? store.filteredMessages.filter((m) => selectedSeqnos.value.has(m.seqno))
-      : store.filteredMessages;
+  const visible = filteredByType.value;
+  const visibleSelected = visible.filter((m) =>
+    selectedSeqnos.value.has(m.seqno),
+  );
+  const msgs = visibleSelected.length > 0 ? visibleSelected : visible;
   const text = msgs.map(formatMessage).join("\n");
   try {
     await navigator.clipboard.writeText(text);
@@ -250,7 +258,7 @@ onKeyStroke("Escape", (e) => {
 
 onKeyStroke("c", (e) => {
   if (isTypingInInput(e) || !(e.ctrlKey || e.metaKey)) return;
-  if (selectedSeqnos.value.size === 0) return;
+  if (visibleSelectedCount.value === 0) return;
   e.preventDefault();
   copySelectedToClipboard();
 });
@@ -284,8 +292,8 @@ onUnmounted(() => {
       </button>
       <button class="btn" @click="copySelectedToClipboard">
         {{
-          selectedSeqnos.size > 0
-            ? $t("messages.copySelected", selectedSeqnos.size)
+          visibleSelectedCount > 0
+            ? $t("messages.copySelected", visibleSelectedCount)
             : $t("messages.copyAll")
         }}
       </button>


### PR DESCRIPTION
## Summary
- Copy All now copies only messages visible under the active type filter (All / User Alerts / Errors), not the entire unfiltered list
- Copy Selected similarly filters against the visible set, so hidden messages cannot be copied even if previously selected
- Added two tests verifying both Copy All and Copy Selected respect the type filter

## Test plan
- [ ] Open Event Log, add messages of different types (Info, Alert, Error)
- [ ] Switch to "Errors" filter, click Copy All — only error messages should be in clipboard
- [ ] Select a single error row, click Copy Selected — only that row should be copied
- [ ] Switch back to "All", verify Copy All copies everything again

Reviewed with Codex before submission.