### PR TITLE
fix(a11y): allow native context menu in editable elements

### DIFF
--- a/src/App.test.ts
+++ b/src/App.test.ts
@@ -343,6 +343,76 @@ describe("App", () => {
     expect(router.currentRoute.value.path).toBe("/tasks");
   });
 
+  it("prevents context menu on non-editable elements", async () => {
+    const router = createTestRouter();
+    await router.push("/tasks");
+    await router.isReady();
+
+    await mountApp(router);
+
+    const event = new MouseEvent("contextmenu", { bubbles: true });
+    const spy = vi.spyOn(event, "preventDefault");
+    document.body.dispatchEvent(event);
+
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it("allows native context menu on text input", async () => {
+    const router = createTestRouter();
+    await router.push("/tasks");
+    await router.isReady();
+
+    await mountApp(router);
+
+    const input = document.createElement("input");
+    input.type = "text";
+    document.body.appendChild(input);
+
+    const event = new MouseEvent("contextmenu", { bubbles: true });
+    const spy = vi.spyOn(event, "preventDefault");
+    input.dispatchEvent(event);
+
+    expect(spy).not.toHaveBeenCalled();
+    input.remove();
+  });
+
+  it("allows native context menu on textarea", async () => {
+    const router = createTestRouter();
+    await router.push("/tasks");
+    await router.isReady();
+
+    await mountApp(router);
+
+    const textarea = document.createElement("textarea");
+    document.body.appendChild(textarea);
+
+    const event = new MouseEvent("contextmenu", { bubbles: true });
+    const spy = vi.spyOn(event, "preventDefault");
+    textarea.dispatchEvent(event);
+
+    expect(spy).not.toHaveBeenCalled();
+    textarea.remove();
+  });
+
+  it("allows native context menu on contenteditable element", async () => {
+    const router = createTestRouter();
+    await router.push("/tasks");
+    await router.isReady();
+
+    await mountApp(router);
+
+    const div = document.createElement("div");
+    div.contentEditable = "true";
+    document.body.appendChild(div);
+
+    const event = new MouseEvent("contextmenu", { bubbles: true });
+    const spy = vi.spyOn(event, "preventDefault");
+    div.dispatchEvent(event);
+
+    expect(spy).not.toHaveBeenCalled();
+    div.remove();
+  });
+
   it("allows Backspace inside text input", async () => {
     const router = createTestRouter();
     await router.push("/tasks");

--- a/src/App.vue
+++ b/src/App.vue
@@ -200,8 +200,13 @@ function cancelAutoConnect() {
 type UnlistenFn = () => void;
 const unlisteners: UnlistenFn[] = [];
 
-// Disable right-click context menu in the entire app
-useEventListener(document, "contextmenu", (e) => e.preventDefault());
+// Disable right-click context menu in the entire app,
+// but allow native context menu in editable elements (input, textarea, contenteditable)
+useEventListener(document, "contextmenu", (e) => {
+  if (!isTextEditable(e.target)) {
+    e.preventDefault();
+  }
+});
 
 // Prevent Backspace from triggering browser-like back navigation in the WebView.
 // Only allow Backspace in text-editable elements (text inputs, textareas, contenteditable).


### PR DESCRIPTION
## Summary
- The global `contextmenu` handler in `App.vue` was blocking native right-click menus everywhere, including text inputs, textareas, and contenteditable elements
- Added a check using the existing `isTextEditable()` helper so editable elements get the native context menu (copy/paste/cut) while non-editable areas still show the custom `ContextMenu`
- Added 4 tests covering: blocked context menu on non-editable elements, allowed on `<input>`, `<textarea>`, and `contenteditable`

## Test plan
- [x] `pnpm lint` — 0 errors
- [x] `pnpm exec vue-tsc --noEmit` — clean
- [x] `pnpm test` — 449 tests passing
- [ ] Manual: right-click on a text input field — native browser context menu should appear
- [ ] Manual: right-click on a table row — custom context menu should appear as before

Reviewed with Codex before submission.