### PR TITLE
fix(notices): do not notify for historical notices on initial sync

### DIFF
--- a/src/stores/notices.test.ts
+++ b/src/stores/notices.test.ts
@@ -60,7 +60,6 @@ describe("useNoticesStore", () => {
 
     expect(store.notices).toEqual(notices);
     expect(mockGetNotices).toHaveBeenCalledWith(0);
-    expect(mockNotify).toHaveBeenCalledWith(2);
   });
 
   it("fetchNotices accumulates across calls", async () => {
@@ -82,6 +81,42 @@ describe("useNoticesStore", () => {
 
     expect(store.notices).toEqual([]);
     expect(mockNotify).not.toHaveBeenCalled();
+  });
+
+  it("does not notify on initial sync (first fetch after store creation)", async () => {
+    mockGetNotices.mockResolvedValueOnce([makeNotice(1), makeNotice(2), makeNotice(3)]);
+    const store = useNoticesStore();
+    await store.fetchNotices();
+
+    expect(store.notices).toHaveLength(3);
+    expect(mockNotify).not.toHaveBeenCalled();
+  });
+
+  it("notifies on second fetch after initial sync", async () => {
+    // First fetch — initial sync, no notification
+    mockGetNotices.mockResolvedValueOnce([makeNotice(1)]);
+    const store = useNoticesStore();
+    await store.fetchNotices();
+    expect(mockNotify).not.toHaveBeenCalled();
+
+    // Second fetch — new notices arrive, should notify
+    mockGetNotices.mockResolvedValueOnce([makeNotice(2), makeNotice(3)]);
+    await store.fetchNotices();
+    expect(mockNotify).toHaveBeenCalledWith(2);
+  });
+
+  it("clears initial catchingUp even when first fetch returns empty", async () => {
+    const store = useNoticesStore();
+
+    // First fetch returns empty
+    mockGetNotices.mockResolvedValueOnce([]);
+    await store.fetchNotices();
+    expect(mockNotify).not.toHaveBeenCalled();
+
+    // Second fetch returns notices — should notify
+    mockGetNotices.mockResolvedValueOnce([makeNotice(1)]);
+    await store.fetchNotices();
+    expect(mockNotify).toHaveBeenCalledWith(1);
   });
 
   it("fetchNotices sets error on failure", async () => {
@@ -144,10 +179,11 @@ describe("useNoticesStore", () => {
   });
 
   it("resetSessionState suppresses notification on first fetch after reset", async () => {
+    // Initial sync (first fetch) — no notification
     mockGetNotices.mockResolvedValueOnce([makeNotice(1)]);
     const store = useNoticesStore();
     await store.fetchNotices();
-    expect(mockNotify).toHaveBeenCalledTimes(1);
+    expect(mockNotify).not.toHaveBeenCalled();
 
     store.resetSessionState();
     mockNotify.mockClear();

--- a/src/stores/notices.ts
+++ b/src/stores/notices.ts
@@ -14,7 +14,7 @@ export const useNoticesStore = defineStore("notices", () => {
   const lastSeqno = ref(0);
   let pollTimer: ReturnType<typeof setInterval> | null = null;
   let generation = 0;
-  let catchingUp = false;
+  let catchingUp = true;
 
   async function fetchNotices() {
     loading.value = true;


### PR DESCRIPTION
## Summary
- Initialize `catchingUp = true` in the notices store so the first fetch after store creation (initial sync) does not trigger desktop notifications
- Historical notices loaded during initial connection are silently absorbed; only genuinely new notices arriving on subsequent polls trigger notifications
- Added 3 new tests covering initial sync behavior; updated existing tests to match

## Test plan
- [ ] Connect to a BOINC client with existing notices — no desktop notification should appear
- [ ] Wait for the next polling interval — new notices should trigger desktop notifications as usual
- [ ] Disconnect and reconnect (`resetSessionState`) — first fetch should again be silent, subsequent ones should notify
- [ ] `pnpm test` — all 448 tests pass

Reviewed with Codex before submission.