### PR TITLE
test(app): eliminate AbortError noise during Vitest teardown

### DIFF
--- a/src/App.test.ts
+++ b/src/App.test.ts
@@ -31,6 +31,25 @@ vi.mock("@tauri-apps/plugin-process", () => ({
   relaunch: vi.fn(),
 }));
 
+// Prevent real fetch() to GitHub API during teardown
+const { mockCheckForUpdates } = vi.hoisted(() => ({
+  mockCheckForUpdates: vi.fn(),
+}));
+vi.mock("./composables/useUpdateCheck", async () => {
+  const { ref } = await import("vue");
+  return {
+    checkForUpdates: mockCheckForUpdates,
+    useUpdateCheck: vi.fn(() => ({
+      updateAvailable: ref(false),
+      dismissed: ref(false),
+      updateOnExit: ref(false),
+      downloaded: ref(false),
+      downloading: ref(false),
+      checkForUpdates: mockCheckForUpdates,
+    })),
+  };
+});
+
 // Mock all RPC calls so autoConnect finishes quickly
 vi.mock("./composables/useRpc", () => ({
   connectLocal: vi.fn().mockResolvedValue(undefined),


### PR DESCRIPTION
## Summary
- Mock `useUpdateCheck` in `App.test.ts` to prevent real `fetch()` calls to GitHub API
- The unmocked `checkForUpdates()` triggered a real HTTP request via happy-dom, which was aborted during environment teardown producing `DOMException [AbortError]` noise in test output

## Test plan
- [x] `pnpm test` passes with clean output (no AbortError)
- [x] All 445 tests still pass across 40 test files
- [x] `pnpm lint` and `vue-tsc --noEmit` pass

Reviewed with Codex before submission.