### PR TITLE
fix(app): unsubscribe matchMedia theme listener on unmount

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref, computed, watch, onMounted, onUnmounted, provide } from "vue";
-import { onKeyStroke, useEventListener } from "@vueuse/core";
+import { onKeyStroke, useEventListener, usePreferredDark } from "@vueuse/core";
 import { useI18n } from "vue-i18n";
 import { invoke } from "@tauri-apps/api/core";
 import { useRoute, useRouter } from "vue-router";
@@ -65,14 +65,7 @@ const prefsInitialTab = ref<"computing" | "manager">("computing");
 const showExitConfirm = ref(false);
 const initializing = ref(true);
 const loadingStatus = ref(t("app.loading.connectingLocal"));
-const isDarkTheme = ref(
-  window.matchMedia?.("(prefers-color-scheme: dark)").matches ?? false,
-);
-window
-  .matchMedia?.("(prefers-color-scheme: dark)")
-  .addEventListener("change", (e) => {
-    isDarkTheme.value = e.matches;
-  });
+const isDarkTheme = usePreferredDark();
 const sidebarOpen = ref(false);
 const collapsedGroups = ref<string[]>(["advanced"]);
 

--- a/src/views/ConnectView.vue
+++ b/src/views/ConnectView.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, computed, onMounted } from "vue";
+import { usePreferredDark } from "@vueuse/core";
 import { useI18n } from "vue-i18n";
 import Tooltip from "../components/Tooltip.vue";
 import {
@@ -62,14 +63,7 @@ const connecting = ref(false);
 const osLoading = ref(true);
 const statusMessage = ref<string | null>(null);
 const recentConnections = ref<RecentConnection[]>([]);
-const isDarkTheme = ref(
-  window.matchMedia?.("(prefers-color-scheme: dark)").matches ?? false,
-);
-window
-  .matchMedia?.("(prefers-color-scheme: dark)")
-  .addEventListener("change", (e) => {
-    isDarkTheme.value = e.matches;
-  });
+const isDarkTheme = usePreferredDark();
 
 onMounted(async () => {
   loadRecent();


### PR DESCRIPTION
## Summary
- Replace manual `matchMedia('(prefers-color-scheme: dark)')` addEventListener (without cleanup) with VueUse `usePreferredDark()` in `App.vue` and `ConnectView.vue`
- The composable handles subscribe/unsubscribe automatically via Vue lifecycle hooks, preventing memory leaks
- Consistent with existing pattern in `AboutDialog.vue` which already uses `usePreferredDark()`

## Test plan
- [ ] Verify dark/light theme detection still works on the loading screen (`App.vue`)
- [ ] Verify dark/light theme detection still works on the connect screen (`ConnectView.vue`)
- [ ] Toggle system theme while the app is running — logo should switch between `icon.png` and `icon-dark.png`
- [ ] All 445 existing tests pass

Reviewed with Codex before submission.