### PR TITLE
refactor(rpc): enforce typed frontend-Rust command contract

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -2,7 +2,7 @@
 import { ref, computed, watch, onMounted, onUnmounted, provide } from "vue";
 import { onKeyStroke, useEventListener } from "@vueuse/core";
 import { useI18n } from "vue-i18n";
-import { invoke } from "@tauri-apps/api/core";
+import { invoke } from "./lib/typedInvoke";
 import { useRoute, useRouter } from "vue-router";
 import { useConnectionStore } from "./stores/connection";
 import { CONNECTION_STATE } from "./types/boinc";

--- a/src/components/AboutDialog.vue
+++ b/src/components/AboutDialog.vue
@@ -2,7 +2,7 @@
 import { computed, nextTick, ref, watch } from "vue";
 import { onKeyStroke, usePreferredDark } from "@vueuse/core";
 import { useI18n } from "vue-i18n";
-import { invoke } from "@tauri-apps/api/core";
+import { invoke } from "../lib/typedInvoke";
 import { useUpdateCheck, startBackgroundDownload } from "../composables/useUpdateCheck";
 import { useFocusTrap } from "@vueuse/integrations/useFocusTrap";
 

--- a/src/components/UpdateBanner.vue
+++ b/src/components/UpdateBanner.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ref } from "vue";
 import { useI18n } from "vue-i18n";
-import { invoke } from "@tauri-apps/api/core";
+import { invoke } from "../lib/typedInvoke";
 import Tooltip from "./Tooltip.vue";
 import {
   useUpdateCheck,

--- a/src/composables/usePlatform.ts
+++ b/src/composables/usePlatform.ts
@@ -1,4 +1,4 @@
-import { invoke } from "@tauri-apps/api/core";
+import { invoke } from "../lib/typedInvoke";
 
 export type OS = "windows" | "macos" | "linux";
 export type Arch = "arm64" | "x86_64";

--- a/src/composables/useRpc.ts
+++ b/src/composables/useRpc.ts
@@ -1,9 +1,10 @@
-import { invoke } from "@tauri-apps/api/core";
+import { invoke } from "../lib/typedInvoke";
 import type {
   TaskResult,
   Project,
   CcStatus,
   CcState,
+  ConnectionState,
   FileTransfer,
   ProjectStatistics,
   Message,
@@ -49,7 +50,7 @@ export async function disconnect(): Promise<void> {
   return invoke("disconnect");
 }
 
-export async function getConnectionState(): Promise<string> {
+export async function getConnectionState(): Promise<ConnectionState> {
   return invoke("get_connection_state");
 }
 

--- a/src/composables/useUpdateCheck.ts
+++ b/src/composables/useUpdateCheck.ts
@@ -1,5 +1,5 @@
 import { ref } from "vue";
-import { invoke } from "@tauri-apps/api/core";
+import { invoke } from "../lib/typedInvoke";
 import { useManagerSettingsStore } from "../stores/managerSettings";
 import { getOS, getArch, platformAssetPattern } from "./usePlatform";
 
@@ -35,7 +35,7 @@ const downloaded = ref(false);
 const downloadError = ref("");
 
 // Fetch build time eagerly so About dialog shows it immediately
-invoke<string>("get_build_time").then((bt) => {
+invoke("get_build_time").then((bt) => {
   buildTime.value = bt;
 });
 

--- a/src/lib/typedInvoke.ts
+++ b/src/lib/typedInvoke.ts
@@ -1,0 +1,193 @@
+import { invoke as rawInvoke } from "@tauri-apps/api/core";
+import type {
+  TaskResult,
+  Project,
+  CcStatus,
+  CcState,
+  FileTransfer,
+  ProjectStatistics,
+  Message,
+  Notice,
+  DiskUsage,
+  GlobalPreferences,
+  HostInfo,
+  ProjectListEntry,
+  AccountOut,
+  ProjectAttachReply,
+  ProjectConfig,
+  AcctMgrInfo,
+  AcctMgrRpcReply,
+  ProxyInfo,
+  CcConfig,
+  NewerVersionInfo,
+  VersionInfo,
+  ProjectInitStatus,
+  DailyXferHistory,
+  OldResult,
+  ConnectionState,
+} from "../types/boinc";
+import type { OS, Arch } from "../composables/usePlatform";
+
+/**
+ * Maps every Tauri command name to its argument object and return type.
+ * Adding/removing/renaming a command here will cause type errors at every
+ * call site, so frontend-Rust drift is caught at type-check time.
+ */
+interface CommandMap {
+  // Connection
+  connect: { args: { host: string; port: number; password: string }; ret: void };
+  connect_local: { args: { dataDir: string }; ret: void };
+  disconnect: { args: Record<string, never>; ret: void };
+  get_connection_state: { args: Record<string, never>; ret: ConnectionState };
+
+  // Read operations
+  get_results: { args: { activeOnly: boolean }; ret: TaskResult[] };
+  get_project_status: { args: Record<string, never>; ret: Project[] };
+  get_cc_status: { args: Record<string, never>; ret: CcStatus };
+  get_transfers: { args: Record<string, never>; ret: FileTransfer[] };
+
+  // Task actions
+  suspend_task: { args: { projectUrl: string; name: string }; ret: void };
+  resume_task: { args: { projectUrl: string; name: string }; ret: void };
+  abort_task: { args: { projectUrl: string; name: string }; ret: void };
+
+  // Project actions
+  suspend_project: { args: { projectUrl: string }; ret: void };
+  resume_project: { args: { projectUrl: string }; ret: void };
+  update_project: { args: { projectUrl: string }; ret: void };
+  no_new_tasks_project: { args: { projectUrl: string }; ret: void };
+  allow_new_tasks_project: { args: { projectUrl: string }; ret: void };
+  reset_project: { args: { projectUrl: string }; ret: void };
+  detach_project: { args: { projectUrl: string }; ret: void };
+
+  // Mode controls
+  set_run_mode: { args: { mode: number; duration: number }; ret: void };
+  set_gpu_mode: { args: { mode: number; duration: number }; ret: void };
+  set_network_mode: { args: { mode: number; duration: number }; ret: void };
+
+  // Transfer actions
+  retry_transfer: { args: { projectUrl: string; filename: string }; ret: void };
+  abort_transfer: { args: { projectUrl: string; filename: string }; ret: void };
+
+  // BOINC client launcher
+  start_boinc_client: { args: { dataDir: string; clientDir: string }; ret: void };
+  detect_boinc_client_dir: { args: Record<string, never>; ret: string };
+
+  // Other
+  run_benchmarks: { args: Record<string, never>; ret: void };
+  retry_pending_transfers: { args: Record<string, never>; ret: void };
+  shutdown_client: { args: Record<string, never>; ret: void };
+
+  // Statistics
+  get_statistics: { args: Record<string, never>; ret: ProjectStatistics[] };
+
+  // Messages & Notices
+  get_messages: { args: { seqno: number }; ret: Message[] };
+  get_notices: { args: { seqno: number }; ret: Notice[] };
+
+  // Disk usage
+  get_disk_usage: { args: Record<string, never>; ret: DiskUsage };
+
+  // Preferences
+  get_preferences: { args: Record<string, never>; ret: GlobalPreferences };
+  set_preferences: { args: { prefs: GlobalPreferences }; ret: void };
+
+  // Host info
+  get_host_info: { args: Record<string, never>; ret: HostInfo };
+
+  // Project attach
+  get_all_projects_list: { args: Record<string, never>; ret: ProjectListEntry[] };
+  lookup_account: { args: { url: string; email: string; password: string }; ret: void };
+  lookup_account_poll: { args: Record<string, never>; ret: AccountOut };
+  project_attach: { args: { url: string; authenticator: string; name: string }; ret: void };
+  project_attach_poll: { args: Record<string, never>; ret: ProjectAttachReply };
+
+  // Project config
+  get_project_config: { args: { url: string }; ret: void };
+  get_project_config_poll: { args: Record<string, never>; ret: ProjectConfig };
+  create_account: {
+    args: { url: string; email: string; passwdHash: string; userName: string; teamName: string };
+    ret: void;
+  };
+  create_account_poll: { args: Record<string, never>; ret: AccountOut };
+  compute_passwd_hash: { args: { email: string; password: string }; ret: string };
+
+  // Account manager
+  acct_mgr_info: { args: Record<string, never>; ret: AcctMgrInfo };
+  acct_mgr_rpc: { args: { url: string; name: string; password: string }; ret: void };
+  acct_mgr_rpc_poll: { args: Record<string, never>; ret: AcctMgrRpcReply };
+
+  // Proxy settings
+  get_proxy_settings: { args: Record<string, never>; ret: ProxyInfo };
+  set_proxy_settings: { args: { proxy: ProxyInfo }; ret: void };
+
+  // CC Config
+  get_cc_config: { args: Record<string, never>; ret: CcConfig };
+  set_cc_config: { args: { config: CcConfig }; ret: void };
+
+  // Version
+  get_newer_version: { args: Record<string, never>; ret: NewerVersionInfo };
+  exchange_versions: { args: Record<string, never>; ret: VersionInfo };
+
+  // Graphics
+  launch_graphics: { args: { path: string }; ret: void };
+  launch_remote_desktop: { args: { addr: string }; ret: void };
+
+  // State
+  get_state: { args: Record<string, never>; ret: CcState };
+
+  // Read commands
+  read_global_prefs_override: { args: Record<string, never>; ret: void };
+  read_cc_config: { args: Record<string, never>; ret: void };
+  get_global_prefs_working: { args: Record<string, never>; ret: GlobalPreferences };
+  get_global_prefs_file: { args: Record<string, never>; ret: GlobalPreferences };
+
+  // Language
+  set_language: { args: { lang: string }; ret: void };
+
+  // Project init
+  get_project_init_status: { args: Record<string, never>; ret: ProjectInitStatus };
+  project_attach_from_file: { args: Record<string, never>; ret: void };
+
+  // Old results
+  get_old_results: { args: Record<string, never>; ret: OldResult[] };
+
+  // Message count
+  get_message_count: { args: Record<string, never>; ret: number };
+
+  // Daily transfer history
+  get_daily_xfer_history: { args: Record<string, never>; ret: DailyXferHistory };
+
+  // Build info
+  get_build_time: { args: Record<string, never>; ret: string };
+  get_platform: { args: Record<string, never>; ret: OS };
+  get_arch: { args: Record<string, never>; ret: Arch };
+
+  // Updater
+  download_update: { args: { assetUrl: string }; ret: void };
+  update_now: { args: { assetUrl: string }; ret: boolean };
+  install_update: { args: Record<string, never>; ret: boolean };
+  cleanup_old_binary: { args: Record<string, never>; ret: void };
+}
+
+type Command = keyof CommandMap;
+
+/**
+ * Typed wrapper around Tauri's invoke().
+ *
+ * For commands with no arguments, call as `invoke("command_name")`.
+ * For commands with arguments, call as `invoke("command_name", { ... })`.
+ *
+ * Both the command name and its argument shape are checked at compile time.
+ */
+export function invoke<C extends Command>(
+  cmd: C,
+  ...args: CommandMap[C]["args"] extends Record<string, never>
+    ? []
+    : [CommandMap[C]["args"]]
+): Promise<CommandMap[C]["ret"]> {
+  if (args.length === 0) {
+    return rawInvoke(cmd);
+  }
+  return rawInvoke(cmd, args[0] as Record<string, unknown>);
+}


### PR DESCRIPTION
## Summary
- Add `src/lib/typedInvoke.ts` — a typed wrapper around Tauri's `invoke()` with a `CommandMap` interface that maps every command name to its argument and return types
- Replace all direct `invoke("string")` imports across 6 files (`useRpc.ts`, `usePlatform.ts`, `useUpdateCheck.ts`, `App.vue`, `AboutDialog.vue`, `UpdateBanner.vue`) with the typed wrapper
- Fix `getConnectionState()` return type from `string` to `ConnectionState` (matching the Rust side)

## Test plan
- [x] `pnpm lint` — 0 warnings, 0 errors
- [x] `pnpm exec vue-tsc --noEmit` — passes with no errors
- [x] `pnpm test` — all 445 tests pass
- [ ] Verify type-check catches drift: temporarily rename a command in `CommandMap` and confirm `vue-tsc` reports errors at all call sites

Reviewed with Codex before submission.