### PR TITLE
fix(i18n): add missing table.hideColumn and table.reorderColumn keys

### DIFF
--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -472,6 +472,10 @@
     "cancel": "Abbrechen",
     "apply": "Übernehmen"
   },
+  "table": {
+    "hideColumn": "Spalte ausblenden",
+    "reorderColumn": "Ziehen zum Neuordnen"
+  },
   "properties": {
     "taskProperties": "Aufgabeneigenschaften",
     "projectProperties": "Projekteigenschaften",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -472,6 +472,10 @@
     "cancel": "Cancelar",
     "apply": "Aplicar"
   },
+  "table": {
+    "hideColumn": "Ocultar columna",
+    "reorderColumn": "Arrastrar para reordenar"
+  },
   "properties": {
     "taskProperties": "Propiedades de la tarea",
     "projectProperties": "Propiedades del proyecto",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -472,6 +472,10 @@
     "cancel": "Annuler",
     "apply": "Appliquer"
   },
+  "table": {
+    "hideColumn": "Masquer la colonne",
+    "reorderColumn": "Glisser pour réorganiser"
+  },
   "properties": {
     "taskProperties": "Propriétés de la tâche",
     "projectProperties": "Propriétés du projet",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -472,6 +472,10 @@
     "cancel": "キャンセル",
     "apply": "適用"
   },
+  "table": {
+    "hideColumn": "列を非表示",
+    "reorderColumn": "ドラッグして並べ替え"
+  },
   "properties": {
     "taskProperties": "タスクのプロパティ",
     "projectProperties": "プロジェクトのプロパティ",

--- a/src/i18n/locales/pt_BR.json
+++ b/src/i18n/locales/pt_BR.json
@@ -472,6 +472,10 @@
     "cancel": "Cancelar",
     "apply": "Aplicar"
   },
+  "table": {
+    "hideColumn": "Ocultar coluna",
+    "reorderColumn": "Arrastar para reordenar"
+  },
   "properties": {
     "taskProperties": "Propriedades da tarefa",
     "projectProperties": "Propriedades do projeto",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -472,6 +472,10 @@
     "cancel": "Отмена",
     "apply": "Применить"
   },
+  "table": {
+    "hideColumn": "Скрыть столбец",
+    "reorderColumn": "Перетащите для изменения порядка"
+  },
   "properties": {
     "taskProperties": "Свойства задания",
     "projectProperties": "Свойства проекта",

--- a/src/i18n/locales/zh_CN.json
+++ b/src/i18n/locales/zh_CN.json
@@ -472,6 +472,10 @@
     "cancel": "取消",
     "apply": "应用"
   },
+  "table": {
+    "hideColumn": "隐藏列",
+    "reorderColumn": "拖动以重新排序"
+  },
   "properties": {
     "taskProperties": "任务属性",
     "projectProperties": "项目属性",


### PR DESCRIPTION
## Summary
- Add missing `table.hideColumn` and `table.reorderColumn` i18n keys to all non-English locales (de, es, fr, ja, pt_BR, ru, zh_CN)
- These keys are used by the DataTable context menu but were only defined in `en.json`, causing raw key strings to appear for non-English users

## Test plan
- [ ] Switch app language to each of the 7 affected locales
- [ ] Right-click a table column header and verify "Hide column" / "Reorder column" labels appear translated (not as raw keys)
- [ ] Confirm English locale still works correctly

Reviewed with Codex before submission.