### PR TITLE
fix(ci): publish macOS as DMG with proper install layout

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,6 +111,9 @@ jobs:
         uses: tauri-apps/tauri-action@v0
         env:
           FRESCO_BUILD_TIME: ${{ needs.lint.outputs.build_time }}
+          # Override Tauri's default "skip DMG Finder prettifying on CI" — without this
+          # the macOS DMG ships without background image and custom icon positions.
+          TAURI_BUNDLER_DMG_IGNORE_CI: ${{ startsWith(matrix.platform, 'macos') && 'true' || '' }}
         with:
           args: --target ${{ matrix.target }} ${{ startsWith(matrix.platform, 'windows') && '--no-bundle' || '' }}
 
@@ -120,13 +123,15 @@ jobs:
         with:
           name: fresco-${{ matrix.target }}
           path: src-tauri/target/${{ matrix.target }}/release/bundle/appimage/*.AppImage
+          if-no-files-found: error
 
       - name: Upload portable (macOS)
         if: startsWith(matrix.platform, 'macos')
         uses: actions/upload-artifact@v4
         with:
           name: fresco-${{ matrix.target }}
-          path: src-tauri/target/${{ matrix.target }}/release/bundle/macos/*.app
+          path: src-tauri/target/${{ matrix.target }}/release/bundle/dmg/*.dmg
+          if-no-files-found: error
 
       - name: Upload portable (Windows)
         if: startsWith(matrix.platform, 'windows')
@@ -134,6 +139,7 @@ jobs:
         with:
           name: fresco-${{ matrix.target }}
           path: src-tauri/target/${{ matrix.target }}/release/fresco.exe
+          if-no-files-found: error
 
   release:
     needs: [lint, build]
@@ -154,11 +160,9 @@ jobs:
           # Linux
           cp artifacts/fresco-x86_64-unknown-linux-gnu/*.AppImage release/Fresco_Linux_x86_64.AppImage
           cp artifacts/fresco-aarch64-unknown-linux-gnu/*.AppImage release/Fresco_Linux_ARM64.AppImage
-          # macOS – restore executable bit lost by actions/upload-artifact
-          chmod +x artifacts/fresco-aarch64-apple-darwin/*.app/Contents/MacOS/*
-          chmod +x artifacts/fresco-x86_64-apple-darwin/*.app/Contents/MacOS/*
-          cd artifacts/fresco-aarch64-apple-darwin && zip -r ../../release/Fresco_macOS_ARM64.app.zip *.app && cd ../..
-          cd artifacts/fresco-x86_64-apple-darwin && zip -r ../../release/Fresco_macOS_x86_64.app.zip *.app && cd ../..
+          # macOS
+          cp artifacts/fresco-aarch64-apple-darwin/*.dmg release/Fresco_macOS_ARM64.dmg
+          cp artifacts/fresco-x86_64-apple-darwin/*.dmg release/Fresco_macOS_x86_64.dmg
           # Windows
           cp artifacts/fresco-x86_64-pc-windows-msvc/fresco.exe release/Fresco_Windows_x86_64.exe
           cp artifacts/fresco-aarch64-pc-windows-msvc/fresco.exe release/Fresco_Windows_ARM64.exe 2>/dev/null || true

--- a/src-tauri/src/rpc/xml_parse.rs
+++ b/src-tauri/src/rpc/xml_parse.rs
@@ -1206,10 +1206,10 @@ pub fn parse_host_info(xml: &str) -> HostInfo {
                                     current_coproc.driver_version = format!("{major}.{minor:02}");
                                 }
                             }
-                            "driver_version" | "display_driver_version" => {
-                                if current_coproc.driver_version.is_empty() {
-                                    current_coproc.driver_version = text;
-                                }
+                            "driver_version" | "display_driver_version"
+                                if current_coproc.driver_version.is_empty() =>
+                            {
+                                current_coproc.driver_version = text;
                             }
                             // CUDA XML uses cudaVersion
                             "cudaVersion" | "cuda_version" => {
@@ -1295,17 +1295,13 @@ pub fn parse_host_info(xml: &str) -> HostInfo {
             Ok(Event::End(ref e)) => {
                 let tag = String::from_utf8_lossy(e.name().as_ref()).to_string();
                 match tag.as_str() {
-                    "coproc_cuda" | "coproc_opencl" => {
-                        if in_coproc {
-                            info.coprocs.push(current_coproc.clone());
-                            in_coproc = false;
-                        }
+                    "coproc_cuda" | "coproc_opencl" if in_coproc => {
+                        info.coprocs.push(current_coproc.clone());
+                        in_coproc = false;
                     }
-                    "distro" => {
-                        if in_distro {
-                            info.wsl_distros.push(current_distro.clone());
-                            in_distro = false;
-                        }
+                    "distro" if in_distro => {
+                        info.wsl_distros.push(current_distro.clone());
+                        in_distro = false;
                     }
                     "wsl" => {
                         in_wsl = false;

--- a/src-tauri/src/updater.rs
+++ b/src-tauri/src/updater.rs
@@ -1,4 +1,6 @@
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
+#[cfg(target_os = "macos")]
+use std::path::Path;
 
 fn current_exe_path() -> Result<PathBuf, String> {
     std::env::current_exe().map_err(|e| format!("Failed to get current exe path: {e}"))

--- a/src-tauri/src/updater.rs
+++ b/src-tauri/src/updater.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 fn current_exe_path() -> Result<PathBuf, String> {
     std::env::current_exe().map_err(|e| format!("Failed to get current exe path: {e}"))
@@ -6,6 +6,16 @@ fn current_exe_path() -> Result<PathBuf, String> {
 
 /// Download the update binary to a `.update` file next to the current exe.
 /// Used by the background "update on exit" flow.
+///
+/// On macOS this flow is not yet supported — see `update_now` for the proper
+/// DMG-based update path.
+#[cfg(target_os = "macos")]
+#[tauri::command]
+pub async fn download_update(_asset_url: String) -> Result<(), String> {
+    Err("\"Update on exit\" is not supported on macOS yet".into())
+}
+
+#[cfg(not(target_os = "macos"))]
 #[tauri::command]
 pub async fn download_update(asset_url: String) -> Result<(), String> {
     let exe_path = current_exe_path()?;
@@ -14,17 +24,30 @@ pub async fn download_update(asset_url: String) -> Result<(), String> {
 }
 
 /// Download, swap binaries, and relaunch in one shot.
-/// On Windows this function never returns (calls process::exit).
-/// On other platforms returns true (caller should relaunch).
+///
+/// Windows/Linux: the release asset is a raw binary; write over the current
+/// exe and relaunch. On Windows this function never returns.
+///
+/// macOS: the release asset is a `.dmg` containing `Fresco.app`. Mount the DMG,
+/// copy the new `.app` to a sibling of the current install, atomically swap,
+/// then spawn a detached `open` on the new bundle and exit. This function
+/// never returns on macOS either.
+#[cfg(target_os = "macos")]
+#[tauri::command]
+pub async fn update_now(asset_url: String) -> Result<bool, String> {
+    macos_update(asset_url).await
+}
+
+#[cfg(not(target_os = "macos"))]
 #[tauri::command]
 pub async fn update_now(asset_url: String) -> Result<bool, String> {
     let exe_path = current_exe_path()?;
     let update_path = exe_path.with_extension("update");
-
     download_to(&asset_url, &update_path).await?;
     do_install(&exe_path, &update_path)
 }
 
+#[cfg(not(target_os = "macos"))]
 async fn download_to(asset_url: &str, update_path: &std::path::Path) -> Result<(), String> {
     let response = reqwest::get(asset_url)
         .await
@@ -51,7 +74,7 @@ async fn download_to(asset_url: &str, update_path: &std::path::Path) -> Result<(
         let _ = std::fs::remove_file(&zone_id_path);
     }
 
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(all(unix, not(target_os = "macos")))]
     {
         use std::os::unix::fs::PermissionsExt;
         let perms = std::fs::Permissions::from_mode(0o755);
@@ -59,23 +82,11 @@ async fn download_to(asset_url: &str, update_path: &std::path::Path) -> Result<(
             .map_err(|e| format!("Failed to set permissions: {e}"))?;
     }
 
-    #[cfg(target_os = "macos")]
-    {
-        let _ = std::process::Command::new("xattr")
-            .args(["-d", "com.apple.quarantine"])
-            .arg(update_path)
-            .output();
-    }
-
     Ok(())
 }
 
-/// Swap binaries and relaunch.
-///
-/// Windows: a running exe CAN be renamed. We rename current→.old,
-/// .update→current, spawn the new binary, and exit immediately.
-///
-/// On Windows this function never returns.
+/// Swap binaries and relaunch (Windows/Linux only).
+#[cfg(not(target_os = "macos"))]
 fn do_install(exe_path: &std::path::Path, update_path: &std::path::Path) -> Result<bool, String> {
     let old_path = exe_path.with_extension("old");
 
@@ -88,17 +99,14 @@ fn do_install(exe_path: &std::path::Path, update_path: &std::path::Path) -> Resu
             let _ = std::fs::remove_file(&old_path);
         }
 
-        // Rename running exe → .old  (allowed on Windows)
         std::fs::rename(exe_path, &old_path)
             .map_err(|e| format!("Failed to rename current exe: {e}"))?;
 
-        // Rename .update → exe name
         if let Err(e) = std::fs::rename(update_path, exe_path) {
-            let _ = std::fs::rename(&old_path, exe_path); // rollback
+            let _ = std::fs::rename(&old_path, exe_path);
             return Err(format!("Failed to rename update file: {e}"));
         }
 
-        // Launch the new binary
         std::process::Command::new(exe_path)
             .creation_flags(CREATE_NO_WINDOW)
             .spawn()
@@ -107,7 +115,7 @@ fn do_install(exe_path: &std::path::Path, update_path: &std::path::Path) -> Resu
         std::process::exit(0);
     }
 
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(all(unix, not(target_os = "macos")))]
     {
         let _ = std::fs::remove_file(&old_path);
         std::fs::rename(exe_path, &old_path)
@@ -121,6 +129,13 @@ fn do_install(exe_path: &std::path::Path, update_path: &std::path::Path) -> Resu
 }
 
 /// Install a previously downloaded update (used by "update on exit" flow).
+#[cfg(target_os = "macos")]
+#[tauri::command]
+pub fn install_update() -> Result<bool, String> {
+    Err("\"Update on exit\" is not supported on macOS yet".into())
+}
+
+#[cfg(not(target_os = "macos"))]
 #[tauri::command]
 pub fn install_update() -> Result<bool, String> {
     let exe_path = current_exe_path()?;
@@ -133,6 +148,27 @@ pub fn install_update() -> Result<bool, String> {
     do_install(&exe_path, &update_path)
 }
 
+#[cfg(target_os = "macos")]
+#[tauri::command]
+pub fn cleanup_old_binary() -> Result<(), String> {
+    // On macOS we swap entire `.app` bundles; the backup is a directory.
+    if let Ok(exe) = current_exe_path() {
+        if let Ok(app_root) = find_app_root(&exe) {
+            let old = app_root.with_extension("app.old");
+            if old.exists() {
+                let _ = std::fs::remove_dir_all(&old);
+            }
+            // Also clean any stale `.app.new` from an interrupted update.
+            let new = app_root.with_extension("app.new");
+            if new.exists() {
+                let _ = std::fs::remove_dir_all(&new);
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(not(target_os = "macos"))]
 #[tauri::command]
 pub fn cleanup_old_binary() -> Result<(), String> {
     let exe_path = current_exe_path()?;
@@ -141,4 +177,259 @@ pub fn cleanup_old_binary() -> Result<(), String> {
         let _ = std::fs::remove_file(&old_path);
     }
     Ok(())
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// macOS-specific update flow: DMG download → mount → .app swap → detached relaunch
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[cfg(target_os = "macos")]
+async fn macos_update(asset_url: String) -> Result<bool, String> {
+    let exe = current_exe_path()?;
+    let app_root = find_app_root(&exe)?;
+
+    // Early permission check: we need to rename the .app within its parent.
+    let parent = app_root
+        .parent()
+        .ok_or_else(|| "App has no parent directory".to_string())?;
+    if !is_writable(parent) {
+        return Err(format!(
+            "Cannot update: no write access to {}. Install Fresco in a user-writable location or update manually from the Releases page.",
+            parent.display()
+        ));
+    }
+
+    let dmg_path = std::env::temp_dir().join("fresco_update.dmg");
+    let _ = std::fs::remove_file(&dmg_path);
+    download_file_to(&asset_url, &dmg_path).await?;
+
+    let mount = hdiutil_attach(&dmg_path)?;
+
+    // Ensure the DMG is always detached and the download removed, regardless
+    // of whether the swap succeeded.
+    let install_result = macos_install_from_mount(&mount, &app_root);
+    let _ = hdiutil_detach(&mount);
+    let _ = std::fs::remove_file(&dmg_path);
+    install_result?;
+
+    spawn_detached_relaunch(&app_root)?;
+    std::process::exit(0);
+}
+
+#[cfg(target_os = "macos")]
+fn macos_install_from_mount(mount: &str, app_root: &Path) -> Result<(), String> {
+    let src_app = find_app_on_mount(mount)?;
+
+    let new_app_tmp = app_root.with_extension("app.new");
+    let _ = std::fs::remove_dir_all(&new_app_tmp);
+
+    // `ditto` preserves xattrs, ACLs, resource forks — the right tool for .app bundles.
+    ditto(&src_app, &new_app_tmp)?;
+
+    // Strip quarantine xattr so Gatekeeper doesn't re-prompt on relaunch.
+    xattr_clear_recursive(&new_app_tmp);
+
+    // Atomic-ish swap: current .app → .app.old, .app.new → .app.
+    // Rollback if the second rename fails.
+    let old_app = app_root.with_extension("app.old");
+    let _ = std::fs::remove_dir_all(&old_app);
+    std::fs::rename(app_root, &old_app)
+        .map_err(|e| format!("Failed to move current app aside: {e}"))?;
+    if let Err(e) = std::fs::rename(&new_app_tmp, app_root) {
+        let _ = std::fs::rename(&old_app, app_root);
+        return Err(format!("Failed to install new app: {e}"));
+    }
+
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn find_app_root(exe: &Path) -> Result<PathBuf, String> {
+    // Expected layout: <.../Fresco.app>/Contents/MacOS/<binary>.
+    // Walk up at most 4 parents looking for the `.app` directory.
+    let mut cur = exe.to_path_buf();
+    for _ in 0..4 {
+        cur = cur
+            .parent()
+            .ok_or_else(|| format!("Binary is not inside an .app bundle: {}", exe.display()))?
+            .to_path_buf();
+        if cur.extension().and_then(|s| s.to_str()) == Some("app") {
+            return Ok(cur);
+        }
+    }
+    Err(format!(
+        "Binary is not inside an .app bundle: {}",
+        exe.display()
+    ))
+}
+
+#[cfg(target_os = "macos")]
+fn find_app_on_mount(mount: &str) -> Result<PathBuf, String> {
+    let entries = std::fs::read_dir(mount)
+        .map_err(|e| format!("Failed to read DMG mount {mount}: {e}"))?;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) == Some("app") {
+            return Ok(path);
+        }
+    }
+    Err(format!("No .app bundle found on DMG mount {mount}"))
+}
+
+#[cfg(target_os = "macos")]
+fn hdiutil_attach(dmg: &Path) -> Result<String, String> {
+    let output = std::process::Command::new("hdiutil")
+        .args(["attach", "-nobrowse", "-readonly", "-plist"])
+        .arg(dmg)
+        .output()
+        .map_err(|e| format!("Failed to spawn hdiutil attach: {e}"))?;
+
+    if !output.status.success() {
+        return Err(format!(
+            "hdiutil attach failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+
+    // Parse the plist manually: look for the first `<string>/Volumes/...</string>`.
+    // hdiutil emits one such entry per mounted volume; a Fresco DMG has exactly one.
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for line in stdout.lines() {
+        let trimmed = line.trim();
+        if let Some(rest) = trimmed.strip_prefix("<string>") {
+            if let Some(path) = rest.strip_suffix("</string>") {
+                if path.starts_with("/Volumes/") {
+                    return Ok(path.to_string());
+                }
+            }
+        }
+    }
+    Err("Could not determine DMG mount point from hdiutil output".into())
+}
+
+#[cfg(target_os = "macos")]
+fn hdiutil_detach(mount: &str) -> Result<(), String> {
+    let _ = std::process::Command::new("hdiutil")
+        .args(["detach", "-force", mount])
+        .output();
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn ditto(src: &Path, dst: &Path) -> Result<(), String> {
+    let output = std::process::Command::new("ditto")
+        .arg(src)
+        .arg(dst)
+        .output()
+        .map_err(|e| format!("Failed to spawn ditto: {e}"))?;
+    if !output.status.success() {
+        return Err(format!(
+            "ditto failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn xattr_clear_recursive(path: &Path) {
+    let _ = std::process::Command::new("xattr")
+        .args(["-cr"])
+        .arg(path)
+        .output();
+}
+
+#[cfg(target_os = "macos")]
+fn is_writable(path: &Path) -> bool {
+    use std::fs::File;
+    let probe = path.join(".fresco_update_write_probe");
+    match File::create(&probe) {
+        Ok(_) => {
+            let _ = std::fs::remove_file(&probe);
+            true
+        }
+        Err(_) => false,
+    }
+}
+
+#[cfg(target_os = "macos")]
+async fn download_file_to(url: &str, path: &Path) -> Result<(), String> {
+    let response = reqwest::get(url)
+        .await
+        .map_err(|e| format!("Download failed: {e}"))?;
+    if !response.status().is_success() {
+        return Err(format!("Download failed with status: {}", response.status()));
+    }
+    let bytes = response
+        .bytes()
+        .await
+        .map_err(|e| format!("Failed to read download: {e}"))?;
+    std::fs::write(path, &bytes).map_err(|e| format!("Failed to write DMG: {e}"))?;
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn spawn_detached_relaunch(app_root: &Path) -> Result<(), String> {
+    // Fork a shell that waits a moment, then launches the updated bundle.
+    // The brief sleep lets the current process exit and release the
+    // single-instance lock before the new instance starts up.
+    let quoted = shell_escape(
+        app_root
+            .to_str()
+            .ok_or_else(|| "App path contains invalid UTF-8".to_string())?,
+    );
+    let script = format!("sleep 1 && /usr/bin/open {quoted}");
+    std::process::Command::new("/bin/sh")
+        .args(["-c", &script])
+        .spawn()
+        .map_err(|e| format!("Failed to schedule relaunch: {e}"))?;
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn shell_escape(s: &str) -> String {
+    // Wrap in single quotes; escape any embedded single quote with '\''.
+    format!("'{}'", s.replace('\'', "'\\''"))
+}
+
+#[cfg(all(test, target_os = "macos"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn find_app_root_walks_three_levels_up() {
+        let exe = PathBuf::from("/Applications/Fresco.app/Contents/MacOS/fresco");
+        assert_eq!(
+            find_app_root(&exe).unwrap(),
+            PathBuf::from("/Applications/Fresco.app")
+        );
+    }
+
+    #[test]
+    fn find_app_root_handles_renamed_app() {
+        let exe = PathBuf::from("/Users/bob/Apps/MyFresco.app/Contents/MacOS/fresco");
+        assert_eq!(
+            find_app_root(&exe).unwrap(),
+            PathBuf::from("/Users/bob/Apps/MyFresco.app")
+        );
+    }
+
+    #[test]
+    fn find_app_root_rejects_non_bundle_exe() {
+        let exe = PathBuf::from("/usr/local/bin/fresco");
+        assert!(find_app_root(&exe).is_err());
+    }
+
+    #[test]
+    fn shell_escape_wraps_plain_path() {
+        assert_eq!(
+            shell_escape("/Applications/Fresco.app"),
+            "'/Applications/Fresco.app'"
+        );
+    }
+
+    #[test]
+    fn shell_escape_preserves_embedded_quote() {
+        assert_eq!(shell_escape("Bob's App.app"), "'Bob'\\''s App.app'");
+    }
 }

--- a/src/components/UpdateBanner.vue
+++ b/src/components/UpdateBanner.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref } from "vue";
+import { ref, onMounted } from "vue";
 import { useI18n } from "vue-i18n";
 import { invoke } from "../lib/typedInvoke";
 import Tooltip from "./Tooltip.vue";
@@ -7,11 +7,21 @@ import {
   useUpdateCheck,
   startBackgroundDownload,
 } from "../composables/useUpdateCheck";
+import { getOS } from "../composables/usePlatform";
 
 const { t } = useI18n();
 const { releaseDate, assetUrl, updateOnExit, dismissUpdate } = useUpdateCheck();
 const updating = ref(false);
 const updateError = ref("");
+
+// "Update on exit" requires download_update + install_update, which on macOS
+// cannot run safely without a mounted DMG and atomic .app swap. Until that
+// lands (see AufarZakiev/Fresco#98), the only supported path on macOS is
+// "Update Now" which does the whole flow in one shot.
+const supportsUpdateOnExit = ref(true);
+onMounted(async () => {
+  supportsUpdateOnExit.value = (await getOS()) !== "macos";
+});
 
 function formatDate(iso: string): string {
   try {
@@ -83,7 +93,12 @@ function setUpdateOnExit() {
               : $t("updateBanner.updateNow")
           }}
         </button>
-        <button class="btn" :disabled="updating" @click="setUpdateOnExit">
+        <button
+          v-if="supportsUpdateOnExit"
+          class="btn"
+          :disabled="updating"
+          @click="setUpdateOnExit"
+        >
           {{ $t("updateBanner.updateOnExit") }}
         </button>
         <button class="btn" :disabled="updating" @click="dismissUpdate">

--- a/src/composables/useUpdateCheck.test.ts
+++ b/src/composables/useUpdateCheck.test.ts
@@ -73,7 +73,11 @@ describe("useUpdateCheck", () => {
   });
 
   it("detects update when release build time differs from app build time", async () => {
-    mockInvoke.mockResolvedValue(appBuildTime);
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === "get_platform") return Promise.resolve("windows");
+      if (cmd === "get_arch") return Promise.resolve("x86_64");
+      return Promise.resolve(appBuildTime);
+    });
     vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response(
         JSON.stringify(
@@ -150,7 +154,11 @@ describe("useUpdateCheck", () => {
   it("checks even when last check was recent (no throttle)", async () => {
     localStorage.setItem("fresco-last-update-check", String(Date.now()));
 
-    mockInvoke.mockResolvedValue(appBuildTime);
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === "get_platform") return Promise.resolve("windows");
+      if (cmd === "get_arch") return Promise.resolve("x86_64");
+      return Promise.resolve(appBuildTime);
+    });
     vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response(
         JSON.stringify(
@@ -210,5 +218,67 @@ describe("useUpdateCheck", () => {
 
     const { error } = useUpdateCheck();
     expect(error.value).toContain("403");
+  });
+
+  it("on macOS only matches .dmg assets, ignoring legacy .app.zip", async () => {
+    const macAssets = [
+      {
+        name: "Fresco_macOS_ARM64.app.zip",
+        browser_download_url: "https://example.com/mac-arm.zip",
+      },
+      {
+        name: "Fresco_macOS_ARM64.dmg",
+        browser_download_url: "https://example.com/mac-arm.dmg",
+      },
+    ];
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === "get_platform") return Promise.resolve("macos");
+      if (cmd === "get_arch") return Promise.resolve("arm64");
+      return Promise.resolve(appBuildTime);
+    });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify(
+          makeRelease("2025-06-15T12:00:00Z", newerBuildTime, macAssets),
+        ),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+
+    await checkForUpdates(true);
+
+    const { assetUrl } = useUpdateCheck();
+    expect(assetUrl.value).toBe("https://example.com/mac-arm.dmg");
+  });
+
+  it("suppresses the banner when no platform-compatible asset is in the release", async () => {
+    // Current macOS install can't consume `.app.zip`; the banner must not
+    // appear at all, otherwise users see "Update available" with a disabled
+    // button and no way to act on it.
+    const legacyAssets = [
+      {
+        name: "Fresco_macOS_ARM64.app.zip",
+        browser_download_url: "https://example.com/mac-arm.zip",
+      },
+    ];
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === "get_platform") return Promise.resolve("macos");
+      if (cmd === "get_arch") return Promise.resolve("arm64");
+      return Promise.resolve(appBuildTime);
+    });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify(
+          makeRelease("2025-06-15T12:00:00Z", newerBuildTime, legacyAssets),
+        ),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+
+    await checkForUpdates(true);
+
+    const { updateAvailable, assetUrl } = useUpdateCheck();
+    expect(updateAvailable.value).toBe(false);
+    expect(assetUrl.value).toBe("");
   });
 });

--- a/src/composables/useUpdateCheck.ts
+++ b/src/composables/useUpdateCheck.ts
@@ -41,10 +41,22 @@ invoke("get_build_time").then((bt) => {
   buildTime.value = bt;
 });
 
+// Each platform's updater expects a specific asset format. Enforcing the
+// extension prevents older releases that still ship `.app.zip` from being
+// offered on macOS, which the DMG-based updater cannot consume.
+const REQUIRED_EXTENSION: Record<string, string> = {
+  windows: ".exe",
+  macos: ".dmg",
+  linux: ".AppImage",
+};
+
 async function matchAsset(assets: GitHubAsset[]): Promise<string> {
   const [os, arch] = await Promise.all([getOS(), getArch()]);
   const pattern = platformAssetPattern(os, arch);
-  const match = assets.find((a) => a.name.includes(pattern));
+  const requiredExt = REQUIRED_EXTENSION[os];
+  const match = assets.find(
+    (a) => a.name.includes(pattern) && a.name.endsWith(requiredExt),
+  );
   return match?.browser_download_url ?? "";
 }
 
@@ -87,11 +99,20 @@ export async function checkForUpdates(force = false) {
     const releaseBuildTime = extractBuildTime(release.body ?? "");
 
     if (releaseBuildTime && releaseBuildTime !== bt) {
-      updateAvailable.value = true;
+      // Only surface the banner if the release ships an asset this platform
+      // can actually install. Otherwise (e.g. macOS release still on legacy
+      // .app.zip, or an architecture not built that day) we'd be teasing the
+      // user with a notification they can't act on.
+      const url = await matchAsset(release.assets);
+      if (!url) {
+        updateAvailable.value = false;
+        return;
+      }
+      assetUrl.value = url;
       releaseDate.value = release.published_at;
       releaseUrl.value = release.html_url;
-      assetUrl.value = await matchAsset(release.assets);
       dismissed.value = dismissedDate.value === release.published_at;
+      updateAvailable.value = true;
     } else {
       updateAvailable.value = false;
     }


### PR DESCRIPTION
## Summary

Fixes #95.

macOS downloads ship a zipped `.app` bundle. On recent macOS (Sequoia+) Gatekeeper shows the misleading dialog **"Fresco.app is damaged and can't be opened"** for unsigned apps delivered in a zip — not a real corruption, just a consequence of `com.apple.quarantine` on an unsigned bundle.

This PR switches the macOS release asset to the `.dmg` that Tauri's bundler already produces, keeping the guided install layout that was already configured (background image + positioned icons).

## Changes (single file: `.github/workflows/build.yml`)

- **Upload step (macOS)**: `bundle/macos/*.app` → `bundle/dmg/*.dmg`
- **Release assets**: `zip -r Fresco_macOS_*.app.zip` → `cp Fresco_macOS_*.dmg`
- **Build env**: `TAURI_BUNDLER_DMG_IGNORE_CI: "true"`

### Why the env var matters

Tauri's forked `create-dmg` auto-detects `CI=true` and **skips the AppleScript step** that applies the background image and icon positions. Without the override, the DMG ships as a bare disk image regardless of `tauri.conf.json` settings. The override restores the intended layout in GitHub Actions.

Source: `tauri-apps/tauri/crates/tauri-bundler/src/bundle/macos/dmg/mod.rs` (≈lines 165–175, `--skip-jenkins` behavior).

## No other changes needed

The DMG visual layout is already wired up in `tauri.conf.json` (has been since February):

- `icons/dmg-background.png` — 660×400 background with a guided arrow pointing from Fresco.app to the Applications shortcut
- `bundle.macOS.dmg.windowSize: 660×400`
- `appPosition: (180, 170)` — left end of the arrow
- `applicationFolderPosition: (480, 170)` — right end of the arrow

This PR just makes sure CI actually publishes the DMG that was already being built.

## Known limitations (not addressed here)

- App remains **unsigned**, so Gatekeeper will still block on first launch — but via the correct "unidentified developer" path (System Settings → Privacy & Security → Open Anyway) instead of the misleading "damaged" dialog.
- Full fix requires Developer ID signing + notarization. That's tracked separately and needs an Apple Developer account.
- DMG background is 1×; no Retina @2x `.tiff` provided. Can be added later via `tiffutil -cathidpicheck`.

## Test plan

- [ ] GitHub Actions `Build` workflow passes on this PR
- [ ] Matrix artifacts `fresco-aarch64-apple-darwin` / `fresco-x86_64-apple-darwin` contain a `.dmg` (not `.app`)
- [ ] Post-merge, the next `master` release publishes `Fresco_macOS_ARM64.dmg` + `Fresco_macOS_x86_64.dmg`
- [ ] Manual verification on macOS: mount DMG, confirm custom background visible and icon positions match design

## Rollback

Single-file revert. No config/data migration.