### PR TITLE
chore: gitignore local IDE skill mirrors

### DIFF
--- a/src/components/AboutDialog.test.ts
+++ b/src/components/AboutDialog.test.ts
@@ -35,7 +35,7 @@ function mountDialog(open = true) {
 
 describe("AboutDialog", () => {
   beforeEach(() => {
-    document.body.querySelectorAll(".dialog-overlay").forEach((el) => el.remove());
+    document.body.innerHTML = "";
   });
 
   it("does not render when closed", () => {

--- a/src/components/AboutDialog.test.ts
+++ b/src/components/AboutDialog.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mount } from "@vue/test-utils";
+import AboutDialog from "./AboutDialog.vue";
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn().mockResolvedValue(""),
+}));
+
+vi.mock("../stores/managerSettings", () => ({
+  useManagerSettingsStore: () => ({
+    settings: { checkForUpdates: true },
+  }),
+}));
+
+vi.mock("@vueuse/integrations/useFocusTrap", () => ({
+  useFocusTrap: () => ({
+    activate: vi.fn(),
+    deactivate: vi.fn(),
+  }),
+}));
+
+function mountDialog(open = true) {
+  return mount(AboutDialog, {
+    props: { open },
+    global: {
+      mocks: {
+        $t: (key: string, params?: Record<string, string>) => {
+          if (params) return `${key}:${JSON.stringify(params)}`;
+          return key;
+        },
+      },
+    },
+  });
+}
+
+describe("AboutDialog", () => {
+  beforeEach(() => {
+    document.body.querySelectorAll(".dialog-overlay").forEach((el) => el.remove());
+  });
+
+  it("does not render when closed", () => {
+    mountDialog(false);
+    expect(document.body.querySelector(".dialog-overlay")).toBeNull();
+  });
+
+  it("renders when open", () => {
+    mountDialog(true);
+    expect(document.body.querySelector(".dialog-overlay")).not.toBeNull();
+  });
+
+  it("has correct ARIA attributes", () => {
+    mountDialog(true);
+    const dialog = document.body.querySelector("[role='dialog']");
+    expect(dialog).not.toBeNull();
+    expect(dialog!.getAttribute("aria-modal")).toBe("true");
+    expect(dialog!.getAttribute("aria-labelledby")).toBe(
+      "about-dialog-title",
+    );
+  });
+
+  it("renders title", () => {
+    mountDialog(true);
+    const title = document.body.querySelector("#about-dialog-title");
+    expect(title).not.toBeNull();
+    expect(title!.textContent).toContain("about.title");
+  });
+
+  it("renders description", () => {
+    mountDialog(true);
+    const overlay = document.body.querySelector(".dialog-overlay");
+    expect(overlay!.textContent).toContain("about.description");
+  });
+
+  it("renders GitHub link button", () => {
+    mountDialog(true);
+    const linkBtn = document.body.querySelector(".link-btn");
+    expect(linkBtn).not.toBeNull();
+    expect(linkBtn!.textContent).toContain("about.github");
+  });
+
+  it("renders check for updates button when no update available", () => {
+    mountDialog(true);
+    const overlay = document.body.querySelector(".dialog-overlay");
+    expect(overlay!.textContent).toContain("about.checkForUpdates");
+  });
+
+  it("emits close on close button click", async () => {
+    const wrapper = mountDialog(true);
+    const closeBtn = document.body.querySelector(
+      ".about-footer .btn",
+    ) as HTMLElement;
+    closeBtn.click();
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.emitted("close")).toBeTruthy();
+  });
+
+  it("emits close on overlay click", async () => {
+    const wrapper = mountDialog(true);
+    const overlay = document.body.querySelector(
+      ".dialog-overlay",
+    ) as HTMLElement;
+    overlay.click();
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.emitted("close")).toBeTruthy();
+  });
+
+  it("emits close on Escape key", async () => {
+    const wrapper = mountDialog(false);
+    await wrapper.setProps({ open: true });
+    await wrapper.vm.$nextTick();
+
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.emitted("close")).toBeTruthy();
+  });
+
+  it("shows logo image", () => {
+    mountDialog(true);
+    const img = document.body.querySelector(
+      ".about-logo img",
+    ) as HTMLImageElement;
+    expect(img).not.toBeNull();
+    // Default usePreferredDark returns false in jsdom
+    expect(img.src).toContain("icon.png");
+  });
+});

--- a/src/components/SelectComputerDialog.test.ts
+++ b/src/components/SelectComputerDialog.test.ts
@@ -53,7 +53,7 @@ function mountDialog(open = true) {
 describe("SelectComputerDialog", () => {
   beforeEach(() => {
     setActivePinia(createPinia());
-    document.body.querySelectorAll(".dialog-overlay").forEach((el) => el.remove());
+    document.body.innerHTML = "";
     mockConnectToRemote.mockReset();
     mockConnectToLocal.mockReset();
     mockState = CONNECTION_STATE.CONNECTED;

--- a/src/components/SelectComputerDialog.test.ts
+++ b/src/components/SelectComputerDialog.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
+import { setActivePinia, createPinia } from "pinia";
+import SelectComputerDialog from "./SelectComputerDialog.vue";
+import { CONNECTION_STATE } from "../types/boinc";
+
+const mockConnectToRemote = vi.fn();
+const mockConnectToLocal = vi.fn();
+let mockState: string = CONNECTION_STATE.CONNECTED;
+let mockError: string | null = null;
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(),
+}));
+
+vi.mock("../stores/connection", () => ({
+  useConnectionStore: () => ({
+    connectToRemote: mockConnectToRemote,
+    connectToLocal: mockConnectToLocal,
+    get state() {
+      return mockState;
+    },
+    get error() {
+      return mockError;
+    },
+  }),
+}));
+
+vi.mock("../composables/usePlatform", () => ({
+  getOS: vi.fn().mockResolvedValue("linux"),
+  defaultDataDir: (os: string) => `/data/${os}`,
+}));
+
+vi.mock("@vueuse/integrations/useFocusTrap", () => ({
+  useFocusTrap: () => ({
+    activate: vi.fn(),
+    deactivate: vi.fn(),
+  }),
+}));
+
+function mountDialog(open = true) {
+  return mount(SelectComputerDialog, {
+    props: { open },
+    global: {
+      plugins: [createPinia()],
+      mocks: {
+        $t: (key: string) => key,
+      },
+    },
+  });
+}
+
+describe("SelectComputerDialog", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    document.body.querySelectorAll(".dialog-overlay").forEach((el) => el.remove());
+    mockConnectToRemote.mockReset();
+    mockConnectToLocal.mockReset();
+    mockState = CONNECTION_STATE.CONNECTED;
+    mockError = null;
+  });
+
+  it("does not render when closed", () => {
+    mountDialog(false);
+    expect(document.body.querySelector(".dialog-overlay")).toBeNull();
+  });
+
+  it("renders when open", () => {
+    mountDialog(true);
+    expect(document.body.querySelector(".dialog-overlay")).not.toBeNull();
+  });
+
+  it("has correct ARIA attributes", () => {
+    mountDialog(true);
+    const dialog = document.body.querySelector("[role='dialog']");
+    expect(dialog).not.toBeNull();
+    expect(dialog!.getAttribute("aria-modal")).toBe("true");
+    expect(dialog!.getAttribute("aria-labelledby")).toBe(
+      "select-computer-dialog-title",
+    );
+  });
+
+  it("renders title", () => {
+    mountDialog(true);
+    const title = document.body.querySelector(
+      "#select-computer-dialog-title",
+    );
+    expect(title).not.toBeNull();
+    expect(title!.textContent).toContain("selectComputer.title");
+  });
+
+  it("renders hostname, port, and password fields", () => {
+    mountDialog(true);
+    const inputs = document.body.querySelectorAll("input");
+    expect(inputs).toHaveLength(3);
+  });
+
+  it("defaults hostname to localhost and port to 31416", () => {
+    mountDialog(true);
+    const inputs = document.body.querySelectorAll("input");
+    expect((inputs[0] as HTMLInputElement).value).toBe("localhost");
+    expect((inputs[1] as HTMLInputElement).value).toBe("31416");
+  });
+
+  it("emits close on close button click", async () => {
+    const wrapper = mountDialog(true);
+    const closeBtn = document.body.querySelector(
+      ".close-btn",
+    ) as HTMLElement;
+    closeBtn.click();
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.emitted("close")).toBeTruthy();
+  });
+
+  it("emits close on Escape key", async () => {
+    const wrapper = mountDialog(false);
+    await wrapper.setProps({ open: true });
+    await wrapper.vm.$nextTick();
+
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.emitted("close")).toBeTruthy();
+  });
+
+  it("calls connectToRemote on Connect button click", async () => {
+    mockConnectToRemote.mockResolvedValue(undefined);
+    mountDialog(true);
+
+    const connectBtn = document.body.querySelector(
+      ".btn-primary",
+    ) as HTMLElement;
+    connectBtn.click();
+    await flushPromises();
+
+    expect(mockConnectToRemote).toHaveBeenCalledWith("localhost", 31416, "");
+  });
+
+  it("emits connected and close on successful remote connection", async () => {
+    mockConnectToRemote.mockResolvedValue(undefined);
+    mockState = CONNECTION_STATE.CONNECTED;
+    const wrapper = mountDialog(true);
+
+    const connectBtn = document.body.querySelector(
+      ".btn-primary",
+    ) as HTMLElement;
+    connectBtn.click();
+    await flushPromises();
+
+    expect(wrapper.emitted("connected")).toBeTruthy();
+    expect(wrapper.emitted("close")).toBeTruthy();
+  });
+
+  it("shows error on failed remote connection", async () => {
+    mockConnectToRemote.mockResolvedValue(undefined);
+    mockState = CONNECTION_STATE.DISCONNECTED;
+    mockError = "Connection refused";
+    mountDialog(true);
+
+    const connectBtn = document.body.querySelector(
+      ".btn-primary",
+    ) as HTMLElement;
+    connectBtn.click();
+    await flushPromises();
+
+    const errorEl = document.body.querySelector(".dialog-error");
+    expect(errorEl).not.toBeNull();
+    expect(errorEl!.textContent).toContain("Connection refused");
+  });
+
+  it("calls connectToLocal on local connect button click", async () => {
+    mockConnectToLocal.mockResolvedValue(undefined);
+    mockState = CONNECTION_STATE.CONNECTED;
+    mountDialog(true);
+
+    const localBtn = document.body.querySelector(
+      ".local-btn",
+    ) as HTMLElement;
+    localBtn.click();
+    await flushPromises();
+
+    expect(mockConnectToLocal).toHaveBeenCalledWith("/data/linux");
+  });
+
+  it("shows error when local connection fails with exception", async () => {
+    mockConnectToLocal.mockRejectedValue(new Error("IPC error"));
+    mountDialog(true);
+
+    const localBtn = document.body.querySelector(
+      ".local-btn",
+    ) as HTMLElement;
+    localBtn.click();
+    await flushPromises();
+
+    const errorEl = document.body.querySelector(".dialog-error");
+    expect(errorEl).not.toBeNull();
+    expect(errorEl!.textContent!.length).toBeGreaterThan(0);
+  });
+
+  it("emits close on overlay click", async () => {
+    const wrapper = mountDialog(true);
+    const overlay = document.body.querySelector(
+      ".dialog-overlay",
+    ) as HTMLElement;
+    overlay.click();
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.emitted("close")).toBeTruthy();
+  });
+});

--- a/src/composables/usePlatform.test.ts
+++ b/src/composables/usePlatform.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(),
+}));
+
+import { invoke } from "@tauri-apps/api/core";
+import {
+  getOS,
+  getArch,
+  defaultDataDir,
+  defaultClientDir,
+  detectClientDir,
+  platformAssetPattern,
+} from "./usePlatform";
+
+const mockInvoke = vi.mocked(invoke);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("defaultDataDir", () => {
+  it("returns Windows path for windows", () => {
+    expect(defaultDataDir("windows")).toBe("C:\\ProgramData\\BOINC");
+  });
+
+  it("returns macOS path for macos", () => {
+    expect(defaultDataDir("macos")).toBe(
+      "/Library/Application Support/BOINC Data",
+    );
+  });
+
+  it("returns Linux path for linux", () => {
+    expect(defaultDataDir("linux")).toBe("/var/lib/boinc-client");
+  });
+});
+
+describe("defaultClientDir", () => {
+  it("returns Windows path for windows", () => {
+    expect(defaultClientDir("windows")).toBe("C:\\Program Files\\BOINC");
+  });
+
+  it("returns macOS path for macos", () => {
+    expect(defaultClientDir("macos")).toBe(
+      "/Applications/BOINCManager.app/Contents/Resources",
+    );
+  });
+
+  it("returns Linux path for linux", () => {
+    expect(defaultClientDir("linux")).toBe("/usr/bin");
+  });
+});
+
+describe("platformAssetPattern", () => {
+  it("generates Windows x86_64 pattern", () => {
+    expect(platformAssetPattern("windows", "x86_64")).toBe(
+      "Windows_x86_64",
+    );
+  });
+
+  it("generates macOS ARM64 pattern", () => {
+    expect(platformAssetPattern("macos", "arm64")).toBe("macOS_ARM64");
+  });
+
+  it("generates Linux x86_64 pattern", () => {
+    expect(platformAssetPattern("linux", "x86_64")).toBe("Linux_x86_64");
+  });
+
+  it("generates Linux ARM64 pattern", () => {
+    expect(platformAssetPattern("linux", "arm64")).toBe("Linux_ARM64");
+  });
+});
+
+describe("getOS", () => {
+  it("invokes get_platform command", async () => {
+    mockInvoke.mockResolvedValue("macos");
+    const result = await getOS();
+    expect(result).toBe("macos");
+    expect(mockInvoke).toHaveBeenCalledWith("get_platform");
+  });
+});
+
+describe("getArch", () => {
+  it("invokes get_arch command", async () => {
+    mockInvoke.mockResolvedValue("arm64");
+    const result = await getArch();
+    expect(result).toBe("arm64");
+    expect(mockInvoke).toHaveBeenCalledWith("get_arch");
+  });
+});
+
+describe("detectClientDir", () => {
+  it("invokes detect_boinc_client_dir command", async () => {
+    mockInvoke.mockResolvedValue("/usr/local/bin");
+    const result = await detectClientDir();
+    expect(result).toBe("/usr/local/bin");
+    expect(mockInvoke).toHaveBeenCalledWith("detect_boinc_client_dir");
+  });
+});

--- a/src/composables/useWindowState.test.ts
+++ b/src/composables/useWindowState.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { nextTick } from "vue";
+
+const mockReplace = vi.fn().mockResolvedValue(undefined);
+const afterEachCallbacks: ((to: { path: string }) => void)[] = [];
+
+vi.mock("vue-router", () => ({
+  useRouter: () => ({
+    replace: mockReplace,
+    afterEach: (cb: (to: { path: string }) => void) => {
+      afterEachCallbacks.push(cb);
+    },
+  }),
+}));
+
+// Must import after mocks
+import { mount } from "@vue/test-utils";
+import { defineComponent } from "vue";
+import { useWindowState } from "./useWindowState";
+
+const STORAGE_KEY = "boinc-window-state";
+
+function mountWithSetup(setup: () => void) {
+  return mount(
+    defineComponent({
+      setup() {
+        setup();
+        return () => null;
+      },
+    }),
+  );
+}
+
+describe("useWindowState", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    afterEachCallbacks.length = 0;
+    mockReplace.mockClear();
+  });
+
+  it("restores last route from localStorage on mount", async () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ lastRoute: "/projects" }));
+
+    mountWithSetup(() => useWindowState());
+    await nextTick();
+
+    expect(mockReplace).toHaveBeenCalledWith("/projects");
+  });
+
+  it("defaults to /tasks when localStorage is empty", async () => {
+    mountWithSetup(() => useWindowState());
+    await nextTick();
+
+    expect(mockReplace).toHaveBeenCalledWith("/tasks");
+  });
+
+  it("does not restore root path '/'", async () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ lastRoute: "/" }));
+
+    mountWithSetup(() => useWindowState());
+    await nextTick();
+
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+
+  it("saves route changes to localStorage", () => {
+    mountWithSetup(() => useWindowState());
+
+    const afterEach = afterEachCallbacks[afterEachCallbacks.length - 1];
+    afterEach({ path: "/statistics" });
+
+    const saved = JSON.parse(localStorage.getItem(STORAGE_KEY)!);
+    expect(saved.lastRoute).toBe("/statistics");
+  });
+
+  it("does not save root path to localStorage", () => {
+    mountWithSetup(() => useWindowState());
+
+    const afterEach = afterEachCallbacks[afterEachCallbacks.length - 1];
+    afterEach({ path: "/" });
+
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it("handles corrupt localStorage gracefully", async () => {
+    localStorage.setItem(STORAGE_KEY, "not-json");
+
+    mountWithSetup(() => useWindowState());
+    await nextTick();
+
+    // Falls back to /tasks
+    expect(mockReplace).toHaveBeenCalledWith("/tasks");
+  });
+});

--- a/src/views/HostInfoView.test.ts
+++ b/src/views/HostInfoView.test.ts
@@ -1,0 +1,317 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
+import HostInfoView from "./HostInfoView.vue";
+import type { HostInfo, Coproc, WslDistro } from "../types/boinc";
+
+const mockGetHostInfo = vi.fn();
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(),
+}));
+
+vi.mock("../composables/useRpc", () => ({
+  getHostInfo: () => mockGetHostInfo(),
+}));
+
+function makeCoproc(overrides: Partial<Coproc> = {}): Coproc {
+  return {
+    coproc_type: "CUDA",
+    name: "NVIDIA RTX 3080",
+    count: 1,
+    available_ram: 10e9,
+    driver_version: "535.129.03",
+    cuda_version: 12010,
+    compute_cap_major: 8,
+    compute_cap_minor: 6,
+    clock_rate: 1710,
+    multiprocessor_count: 68,
+    peak_flops: 29.77e12,
+    opencl_device_version: "",
+    opencl_driver_version: "",
+    vendor: "",
+    ...overrides,
+  };
+}
+
+function makeWslDistro(overrides: Partial<WslDistro> = {}): WslDistro {
+  return {
+    distro_name: "Ubuntu-22.04",
+    os_name: "Ubuntu",
+    os_version: "22.04",
+    wsl_version: "2",
+    is_buda_runner: false,
+    buda_runner_version: 0,
+    docker_version: "",
+    docker_type: "",
+    ...overrides,
+  };
+}
+
+function makeHostInfo(overrides: Partial<HostInfo> = {}): HostInfo {
+  return {
+    domain_name: "test-host",
+    ip_addr: "192.168.1.100",
+    p_ncpus: 8,
+    p_vendor: "GenuineIntel",
+    p_model: "Intel Core i7-10700K",
+    p_fpops: 3.29e9,
+    p_iops: 6.58e9,
+    m_nbytes: 34.4e9,
+    m_cache: 16.8e6,
+    m_swap: 8.6e9,
+    d_total: 512.1e9,
+    d_free: 214.7e9,
+    os_name: "Linux",
+    os_version: "Ubuntu 22.04",
+    product_name: "System Product Name",
+    virtualbox_version: "7.0.14",
+    timezone: 10800,
+    host_cpid: "abc123",
+    p_features: "sse sse2 avx",
+    p_membw: 0,
+    p_calculated: 0,
+    p_vm_extensions_disabled: false,
+    mac_address: "00:11:22:33:44:55",
+    docker_version: "",
+    coprocs: [],
+    wsl_distros: [],
+    ...overrides,
+  };
+}
+
+function mountView() {
+  return mount(HostInfoView, {
+    global: {
+      stubs: { PageHeader: true },
+      mocks: {
+        $t: (key: string) => key,
+      },
+    },
+  });
+}
+
+describe("HostInfoView", () => {
+  beforeEach(() => {
+    mockGetHostInfo.mockReset();
+  });
+
+  it("shows loading state initially", () => {
+    mockGetHostInfo.mockReturnValue(new Promise(() => {}));
+    const wrapper = mountView();
+    expect(wrapper.text()).toContain("host.loading");
+  });
+
+  it("renders system info after loading", async () => {
+    mockGetHostInfo.mockResolvedValue(makeHostInfo());
+    const wrapper = mountView();
+    await flushPromises();
+
+    expect(wrapper.text()).toContain("test-host");
+    expect(wrapper.text()).toContain("192.168.1.100");
+    expect(wrapper.text()).toContain("Linux");
+    expect(wrapper.text()).toContain("Ubuntu 22.04");
+  });
+
+  it("renders processor info", async () => {
+    mockGetHostInfo.mockResolvedValue(makeHostInfo());
+    const wrapper = mountView();
+    await flushPromises();
+
+    expect(wrapper.text()).toContain("8");
+    expect(wrapper.text()).toContain("GenuineIntel");
+    expect(wrapper.text()).toContain("Intel Core i7-10700K");
+  });
+
+  it("formats GFLOPS correctly", async () => {
+    mockGetHostInfo.mockResolvedValue(makeHostInfo({ p_fpops: 3.29e9 }));
+    const wrapper = mountView();
+    await flushPromises();
+
+    expect(wrapper.text()).toContain("3.29 GFLOPS");
+  });
+
+  it("formats GIOPS correctly", async () => {
+    mockGetHostInfo.mockResolvedValue(makeHostInfo({ p_iops: 6.58e9 }));
+    const wrapper = mountView();
+    await flushPromises();
+
+    expect(wrapper.text()).toContain("6.58 GIOPS");
+  });
+
+  it("shows --- for zero GFLOPS/GIOPS", async () => {
+    mockGetHostInfo.mockResolvedValue(
+      makeHostInfo({ p_fpops: 0, p_iops: 0 }),
+    );
+    const wrapper = mountView();
+    await flushPromises();
+
+    const text = wrapper.text();
+    expect(text).toContain("---");
+  });
+
+  it("formats memory in GB", async () => {
+    mockGetHostInfo.mockResolvedValue(makeHostInfo({ m_nbytes: 34.4e9 }));
+    const wrapper = mountView();
+    await flushPromises();
+
+    expect(wrapper.text()).toContain("34.4 GB");
+  });
+
+  it("formats cache in MB", async () => {
+    mockGetHostInfo.mockResolvedValue(makeHostInfo({ m_cache: 16.8e6 }));
+    const wrapper = mountView();
+    await flushPromises();
+
+    expect(wrapper.text()).toContain("16.8 MB");
+  });
+
+  it("formats disk in GB", async () => {
+    mockGetHostInfo.mockResolvedValue(
+      makeHostInfo({ d_total: 512.1e9, d_free: 214.7e9 }),
+    );
+    const wrapper = mountView();
+    await flushPromises();
+
+    expect(wrapper.text()).toContain("512.1 GB");
+    expect(wrapper.text()).toContain("214.7 GB");
+  });
+
+  it("shows error message on fetch failure", async () => {
+    mockGetHostInfo.mockRejectedValue(new Error("Connection lost"));
+    const wrapper = mountView();
+    await flushPromises();
+
+    expect(wrapper.find(".error-text").text()).toContain("Connection lost");
+  });
+
+  it("renders GPU card for CUDA coproc", async () => {
+    const gpu = makeCoproc();
+    mockGetHostInfo.mockResolvedValue(makeHostInfo({ coprocs: [gpu] }));
+    const wrapper = mountView();
+    await flushPromises();
+
+    expect(wrapper.text()).toContain("NVIDIA RTX 3080");
+    expect(wrapper.text()).toContain("10.0 GB");
+    expect(wrapper.text()).toContain("535.129.03");
+  });
+
+  it("formats CUDA version correctly", async () => {
+    const gpu = makeCoproc({ cuda_version: 12010 });
+    mockGetHostInfo.mockResolvedValue(makeHostInfo({ coprocs: [gpu] }));
+    const wrapper = mountView();
+    await flushPromises();
+
+    expect(wrapper.text()).toContain("12.1");
+  });
+
+  it("formats CUDA version with zero minor", async () => {
+    const gpu = makeCoproc({ cuda_version: 11000 });
+    mockGetHostInfo.mockResolvedValue(makeHostInfo({ coprocs: [gpu] }));
+    const wrapper = mountView();
+    await flushPromises();
+
+    expect(wrapper.text()).toContain("11.0");
+  });
+
+  it("merges CUDA and OpenCL entries for same GPU", async () => {
+    const cuda = makeCoproc({
+      coproc_type: "CUDA",
+      name: "NVIDIA RTX 3080",
+      vendor: "",
+      opencl_device_version: "",
+    });
+    const opencl = makeCoproc({
+      coproc_type: "OpenCL",
+      name: "NVIDIA RTX 3080",
+      vendor: "NVIDIA Corporation",
+      opencl_device_version: "OpenCL 3.0",
+      cuda_version: 0,
+      compute_cap_major: 0,
+      compute_cap_minor: 0,
+    });
+    mockGetHostInfo.mockResolvedValue(
+      makeHostInfo({ coprocs: [cuda, opencl] }),
+    );
+    const wrapper = mountView();
+    await flushPromises();
+
+    // Should show only one GPU card (merged)
+    const cards = wrapper.findAll(".card-title");
+    const gpuCards = cards.filter((c) => c.text().includes("host.gpu"));
+    expect(gpuCards).toHaveLength(1);
+
+    // Should have OpenCL version from the OpenCL entry
+    expect(wrapper.text()).toContain("OpenCL 3.0");
+  });
+
+  it("shows OpenCL-only GPU when no CUDA entries", async () => {
+    const opencl = makeCoproc({
+      coproc_type: "OpenCL",
+      name: "Intel UHD 630",
+      cuda_version: 0,
+    });
+    mockGetHostInfo.mockResolvedValue(makeHostInfo({ coprocs: [opencl] }));
+    const wrapper = mountView();
+    await flushPromises();
+
+    expect(wrapper.text()).toContain("Intel UHD 630");
+  });
+
+  it("shows VM extensions enabled/disabled", async () => {
+    mockGetHostInfo.mockResolvedValue(
+      makeHostInfo({ p_vm_extensions_disabled: false }),
+    );
+    const wrapper = mountView();
+    await flushPromises();
+
+    expect(wrapper.text()).toContain("host.vmEnabled");
+  });
+
+  it("shows Install link when no buda runner", async () => {
+    mockGetHostInfo.mockResolvedValue(makeHostInfo({ wsl_distros: [] }));
+    const wrapper = mountView();
+    await flushPromises();
+
+    expect(wrapper.find(".install-btn").exists()).toBe(true);
+    expect(wrapper.find(".install-btn").text()).toContain("host.install");
+  });
+
+  it("shows buda runner info and expands on click", async () => {
+    const distro = makeWslDistro({
+      is_buda_runner: true,
+      distro_name: "Ubuntu-22.04",
+      docker_version: "24.0.7",
+    });
+    mockGetHostInfo.mockResolvedValue(
+      makeHostInfo({ wsl_distros: [distro] }),
+    );
+    const wrapper = mountView();
+    await flushPromises();
+
+    expect(wrapper.text()).toContain("host.installed");
+    expect(wrapper.find(".sub-row").exists()).toBe(false);
+
+    // Click to expand
+    await wrapper.find(".wsl-header.clickable").trigger("click");
+
+    expect(wrapper.find(".sub-row").exists()).toBe(true);
+    expect(wrapper.text()).toContain("Ubuntu-22.04");
+    expect(wrapper.text()).toContain("24.0.7");
+  });
+
+  it("shows --- for missing domain_name", async () => {
+    mockGetHostInfo.mockResolvedValue(makeHostInfo({ domain_name: "" }));
+    const wrapper = mountView();
+    await flushPromises();
+
+    expect(wrapper.text()).toContain("---");
+  });
+
+  it("shows 0.0 GB for zero memory", async () => {
+    mockGetHostInfo.mockResolvedValue(makeHostInfo({ m_nbytes: 0 }));
+    const wrapper = mountView();
+    await flushPromises();
+
+    expect(wrapper.text()).toContain("0.0 GB");
+  });
+});


### PR DESCRIPTION
Локальные симлинки в .cursor/skills/ и .codex/skills/ для работы в Cursor + Codex IDE наряду с Claude Code. Игнорируются — зависят от локального FS пути.