### PR TITLE
feat(onboarding): first-run dialogs for manager takeover and install

### DIFF
--- a/agent_docs/development-history.md
+++ b/agent_docs/development-history.md
@@ -8,3 +8,23 @@
 Краткий журнал итераций проекта.
 
 ## Записи
+
+## [2026-04-19] - PR: BOINC first-run onboarding (takeover + install)
+
+### Что сделано
+- Объединённый upstream PR https://github.com/AufarZakiev/Fresco/pull/99 на ветке `feat/boinc-manager-takeover`.
+- **Takeover**: `ManagerAutostartInfo` enum + команды `detect_boinc_manager_autostart`, `disable_boinc_manager_autostart`, `open_login_items_settings` в `src-tauri/src/lib.rs`. `OnboardingTakeoverDialog.vue`, хук в `App.vue` autoConnect, флаг `onboardingCompleted`, i18n `onboarding.takeover.*`.
+- **Install** (первоначально планировался отдельным PR 2, влит сюда): команды `detect_boinc_install_options` + `install_boinc_via_brew`, расширен `resolve_boinc_exe` (Homebrew-пути на macOS). `BoincInstallDialog.vue` + тест, `runInstallOnboardingIfNeeded` в `App.vue`, флаг `installOnboardingCompleted`, i18n `onboarding.install.*`. brew-таймаут 900s.
+- Codex review (takeover): 3 замечания исправлены.
+
+### Зачем
+На первом запуске пользователь мог получить два «лица BOINC» (Fresco рядом с официальным Manager) либо пустой ConnectView без подсказок, если BOINC не установлен. Оба онбординга живут в одном fallback-пути `autoConnect` и решают один сценарий первого запуска.
+
+### Обновлено
+- [x] Тесты: все фронт зелёные (593) + Rust unit (57)
+- [x] agent_docs/development-history.md
+- [ ] agent_docs/adr.md — не требуется
+- [x] todo.md — устарел, PR 2 влит в #99
+
+### Следующие шаги
+- Ждать фидбек @AufarZakiev на объединённом #99.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1094,8 +1094,10 @@ dependencies = [
  "tauri-plugin-opener",
  "tauri-plugin-process",
  "tauri-plugin-single-instance",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "winreg 0.55.0",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -17,7 +17,7 @@ tauri = { version = "2", features = ["tray-icon"] }
 tauri-plugin-opener = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tokio = { version = "1", features = ["net", "io-util", "sync", "time", "rt"] }
+tokio = { version = "1", features = ["net", "io-util", "sync", "time", "rt", "process"] }
 quick-xml = { version = "0.37", features = ["serialize"] }
 md-5 = "0.10"
 hex = "0.4"
@@ -30,6 +30,9 @@ reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"
 tauri-plugin-process = "2"
 tauri-plugin-autostart = "2"
 
+[target.'cfg(windows)'.dependencies]
+winreg = "0.55"
+
 [profile.release]
 opt-level = "s"
 lto = "fat"
@@ -39,3 +42,4 @@ panic = "abort"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full", "test-util"] }
+tempfile = "3"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -22,6 +22,8 @@ const BOINC_TIMEOUT_EXISTING_SECS: u64 = 300;
 const BOINC_TIMEOUT_FRESH_SECS: u64 = 180;
 const BOINC_RPC_ADDR: &str = "127.0.0.1:31416";
 const BOINC_CONNECT_POLL_MS: u64 = 500;
+const BREW_INSTALL_TIMEOUT_SECS: u64 = 900;
+const BOINC_DOWNLOAD_URL: &str = "https://boinc.berkeley.edu/download.php";
 
 pub(crate) struct AppState {
     client: Arc<Mutex<Option<RpcClient>>>,
@@ -800,6 +802,8 @@ fn resolve_boinc_exe(client_dir: &str) -> Result<String, String> {
             vec![
                 "/Applications/BOINCManager.app/Contents/Resources/boinc".to_string(),
                 "/Library/Application Support/BOINC Data/boinc".to_string(),
+                "/opt/homebrew/bin/boinc".to_string(),
+                "/usr/local/bin/boinc".to_string(),
             ]
         } else {
             vec!["/usr/bin/boinc".to_string()]
@@ -837,6 +841,104 @@ fn detect_boinc_client_dir() -> Result<String, String> {
         .map(|p| p.to_string_lossy().to_string())
         .unwrap_or_else(|| exe_path.clone());
     Ok(parent)
+}
+
+#[derive(serde::Serialize)]
+struct BoincInstallOptions {
+    boinc_present: bool,
+    platform: &'static str,
+    package_managers: Vec<String>,
+    official_download_url: &'static str,
+}
+
+fn current_platform() -> &'static str {
+    if cfg!(target_os = "windows") {
+        "windows"
+    } else if cfg!(target_os = "macos") {
+        "macos"
+    } else {
+        "linux"
+    }
+}
+
+fn probe_package_managers() -> Vec<String> {
+    if cfg!(target_os = "windows") {
+        return Vec::new();
+    }
+    let candidates: &[&str] = if cfg!(target_os = "macos") {
+        &["brew"]
+    } else {
+        // Linux: only PMs the frontend has a command mapping for. brew on
+        // Linux exists but we don't render a brew-on-Linux install command,
+        // so probing for it would mislead the UI.
+        &["apt", "dnf", "pacman"]
+    };
+    let mut found = Vec::new();
+    for pm in candidates {
+        let mut cmd = std::process::Command::new(pm);
+        cmd.arg("--version");
+        cmd.stdout(std::process::Stdio::null());
+        cmd.stderr(std::process::Stdio::null());
+        if let Ok(status) = cmd.status() {
+            if status.success() {
+                found.push((*pm).to_string());
+            }
+        }
+    }
+    found
+}
+
+#[tauri::command]
+fn detect_boinc_install_options() -> BoincInstallOptions {
+    BoincInstallOptions {
+        boinc_present: resolve_boinc_exe("").is_ok(),
+        platform: current_platform(),
+        package_managers: probe_package_managers(),
+        official_download_url: BOINC_DOWNLOAD_URL,
+    }
+}
+
+#[tauri::command]
+async fn install_boinc_via_brew() -> Result<(), String> {
+    if !cfg!(target_os = "macos") {
+        return Err("macOS-only".to_string());
+    }
+
+    // `kill_on_drop(true)` ensures that if the wrapping `tokio::time::timeout`
+    // fires we actually terminate `brew` instead of leaking a long-running
+    // background install (which could race with a user retry).
+    let child = tokio::process::Command::new("brew")
+        .args(["install", "boinc"])
+        .kill_on_drop(true)
+        .spawn()
+        .map_err(|e| format!("Failed to spawn brew: {e}"))?;
+
+    let output = match tokio::time::timeout(
+        std::time::Duration::from_secs(BREW_INSTALL_TIMEOUT_SECS),
+        child.wait_with_output(),
+    )
+    .await
+    {
+        Err(_) => {
+            return Err(format!(
+                "brew install timed out after {}s",
+                BREW_INSTALL_TIMEOUT_SECS
+            ));
+        }
+        Ok(inner) => inner.map_err(|e| format!("Failed to run brew: {e}"))?,
+    };
+
+    if output.status.success() {
+        return Ok(());
+    }
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let trimmed: String = stderr.chars().take(200).collect();
+    Err(if trimmed.is_empty() {
+        format!("brew install failed (exit {})", output.status)
+    } else {
+        trimmed
+    })
 }
 
 #[tauri::command]
@@ -886,6 +988,646 @@ async fn start_boinc_client(data_dir: String, client_dir: String) -> Result<(), 
             ));
         }
         tokio::time::sleep(std::time::Duration::from_millis(BOINC_CONNECT_POLL_MS)).await;
+    }
+}
+
+// ── Manager autostart detection ─────────────────────────────────
+
+/// Describes a discovered autostart registration for the official BOINC Manager.
+///
+/// Returned by [`detect_boinc_manager_autostart`] and fed back into
+/// [`disable_boinc_manager_autostart`] so the frontend doesn't need to know
+/// platform details.
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, PartialEq, Eq)]
+#[serde(tag = "kind", content = "data")]
+enum ManagerAutostartInfo {
+    /// macOS: explicit launchd plist (`~/Library/LaunchAgents/*.plist` or
+    /// system-wide `/Library/LaunchAgents`, `/Library/LaunchDaemons`).
+    MacLaunchAgent { plist_path: String },
+    /// macOS: Manager.app is installed but no plist was found. On Sequoia+
+    /// BOINC installers register Login Items via SMAppService, which is opaque
+    /// and cannot be edited programmatically by third-party apps.
+    MacLoginItem,
+    /// Windows: `HKCU\...\Run\<value>` or `HKLM\...\Run\<value>`.
+    WindowsRunKey { hive: String, value_name: String },
+    /// Windows: `.lnk` shortcut in the user's Startup folder.
+    WindowsStartupShortcut { lnk_path: String },
+    /// Linux: XDG autostart `.desktop` file.
+    LinuxAutostart { desktop_path: String, system_wide: bool },
+}
+
+/// Filenames that indicate a BOINC Manager launchd unit.
+///
+/// The official Berkeley installer uses `edu.berkeley.boinc.Manager.plist`;
+/// historical/3rd-party packaging may use `BOINCManager` or similar.
+#[cfg(any(target_os = "macos", test))]
+fn is_manager_plist_name(name: &str) -> bool {
+    let lower = name.to_ascii_lowercase();
+    if !lower.ends_with(".plist") {
+        return false;
+    }
+    // We specifically do NOT match the client daemon ("edu.berkeley.boinc"
+    // without ".Manager"). Disabling the daemon would stop computation.
+    (lower.starts_with("edu.berkeley.boinc.manager")
+        || lower.contains("boincmanager")
+        || lower.contains("boinc.manager"))
+        && !lower.ends_with(".fresco-disabled")
+}
+
+/// Filenames that indicate a BOINC Manager XDG autostart entry on Linux.
+/// Compiled on every platform so the shared `disable_boinc_manager_autostart`
+/// validator can reject bogus `LinuxAutostart` paths without needing OS-
+/// specific glue.
+fn is_manager_desktop_name(name: &str) -> bool {
+    let lower = name.to_ascii_lowercase();
+    if !lower.ends_with(".desktop") {
+        return false;
+    }
+    (lower.contains("boincmgr") || lower.contains("boinc-manager") || lower == "boinc.desktop")
+        && !lower.ends_with(".fresco-disabled")
+}
+
+/// Scan a list of directories for the first file whose name satisfies `predicate`.
+///
+/// Returns the full path of the match, or `None` if nothing is found.
+/// Missing directories are silently skipped (expected on machines where the
+/// Manager isn't installed).
+#[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows", test))]
+fn find_first_matching_file(dirs: &[std::path::PathBuf], predicate: fn(&str) -> bool) -> Option<std::path::PathBuf> {
+    for dir in dirs {
+        let Ok(entries) = std::fs::read_dir(dir) else { continue };
+        for entry in entries.flatten() {
+            let name = entry.file_name();
+            let Some(name_str) = name.to_str() else { continue };
+            if predicate(name_str) {
+                return Some(entry.path());
+            }
+        }
+    }
+    None
+}
+
+#[cfg(target_os = "macos")]
+fn mac_launchagent_dirs() -> Vec<std::path::PathBuf> {
+    // User-level entries come first because detection stops at the first
+    // match, and disabling a per-user LaunchAgent doesn't require root.
+    let mut dirs = Vec::new();
+    if let Some(home) = std::env::var_os("HOME") {
+        dirs.push(std::path::PathBuf::from(home).join("Library/LaunchAgents"));
+    }
+    dirs.push(std::path::PathBuf::from("/Library/LaunchAgents"));
+    dirs.push(std::path::PathBuf::from("/Library/LaunchDaemons"));
+    dirs
+}
+
+#[cfg(target_os = "linux")]
+fn linux_autostart_dirs() -> Vec<(std::path::PathBuf, bool)> {
+    // User-level entries are preferred over system-wide because we can
+    // disable them without root. Detection stops at the first match,
+    // so order matters.
+    let mut dirs = Vec::new();
+    if let Some(home) = std::env::var_os("HOME") {
+        dirs.push((std::path::PathBuf::from(home).join(".config/autostart"), false));
+    }
+    dirs.push((std::path::PathBuf::from("/etc/xdg/autostart"), true));
+    dirs
+}
+
+#[cfg(target_os = "macos")]
+fn macos_major_version() -> Option<u32> {
+    let output = std::process::Command::new("sw_vers")
+        .arg("-productVersion")
+        .output()
+        .ok()?;
+    let ver = String::from_utf8_lossy(&output.stdout);
+    ver.trim().split('.').next()?.parse::<u32>().ok()
+}
+
+#[tauri::command]
+fn detect_boinc_manager_autostart() -> Result<Option<ManagerAutostartInfo>, String> {
+    #[cfg(target_os = "macos")]
+    {
+        let dirs = mac_launchagent_dirs();
+        if let Some(path) = find_first_matching_file(&dirs, is_manager_plist_name) {
+            return Ok(Some(ManagerAutostartInfo::MacLaunchAgent {
+                plist_path: path.to_string_lossy().into_owned(),
+            }));
+        }
+        // No plist found — fall back to detecting the app bundle, but only on
+        // macOS 13+ where SMAppService Login Items replaced editable plists.
+        // On older macOS a BOINC Manager install without a plist almost
+        // certainly means autostart isn't configured; we don't want to prompt
+        // the takeover dialog for users who never registered autostart.
+        // Full SMAppService introspection needs native API (out of scope);
+        // this gate avoids the common false positive.
+        if macos_major_version().is_some_and(|v| v >= 13)
+            && std::path::Path::new("/Applications/BOINCManager.app").exists()
+        {
+            return Ok(Some(ManagerAutostartInfo::MacLoginItem));
+        }
+        Ok(None)
+    }
+    #[cfg(target_os = "windows")]
+    {
+        windows_detect_manager_run_key().map(|opt| opt.or_else(windows_detect_startup_shortcut))
+    }
+    #[cfg(target_os = "linux")]
+    {
+        for (dir, system_wide) in linux_autostart_dirs() {
+            if let Some(path) = find_first_matching_file(&[dir], is_manager_desktop_name) {
+                return Ok(Some(ManagerAutostartInfo::LinuxAutostart {
+                    desktop_path: path.to_string_lossy().into_owned(),
+                    system_wide,
+                }));
+            }
+        }
+        Ok(None)
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn windows_detect_manager_run_key() -> Result<Option<ManagerAutostartInfo>, String> {
+    use winreg::enums::*;
+    use winreg::types::FromRegValue;
+    use winreg::RegKey;
+
+    for (hive_name, hkey) in [("HKCU", HKEY_CURRENT_USER), ("HKLM", HKEY_LOCAL_MACHINE)] {
+        let root = RegKey::predef(hkey);
+        let Ok(run) = root.open_subkey(r"Software\Microsoft\Windows\CurrentVersion\Run") else {
+            continue;
+        };
+        for (value_name, value) in run.enum_values().flatten() {
+            // Only REG_SZ / REG_EXPAND_SZ carry a launch command. Skip other
+            // types instead of matching on the Debug-formatted representation,
+            // which was unreliable for non-string registry types.
+            if !matches!(value.vtype, REG_SZ | REG_EXPAND_SZ) {
+                continue;
+            }
+            let Ok(data) = String::from_reg_value(&value) else {
+                continue;
+            };
+            if data.to_ascii_lowercase().contains("boincmgr") {
+                return Ok(Some(ManagerAutostartInfo::WindowsRunKey {
+                    hive: hive_name.to_string(),
+                    value_name,
+                }));
+            }
+        }
+    }
+    Ok(None)
+}
+
+#[cfg(target_os = "windows")]
+fn windows_detect_startup_shortcut() -> Option<ManagerAutostartInfo> {
+    // Scan the per-user Startup folder for a .lnk whose name suggests BOINC
+    // Manager. We don't parse the .lnk target — name-matching is enough for
+    // the common installer layouts and keeps us dependency-free.
+    let appdata = std::env::var_os("APPDATA")?;
+    let startup = std::path::PathBuf::from(appdata)
+        .join(r"Microsoft\Windows\Start Menu\Programs\Startup");
+    let predicate = |name: &str| -> bool {
+        let lower = name.to_ascii_lowercase();
+        lower.ends_with(".lnk")
+            && (lower.contains("boincmgr") || lower.contains("boinc manager"))
+            && !lower.ends_with(".fresco-disabled")
+    };
+    find_first_matching_file(&[startup], predicate)
+        .map(|path| ManagerAutostartInfo::WindowsStartupShortcut {
+            lnk_path: path.to_string_lossy().into_owned(),
+        })
+}
+
+/// Validate that a filesystem path is a plausible BOINC Manager autostart
+/// entry before we mutate it. Guards against an XSS-compromised frontend
+/// passing an arbitrary user-writable path into
+/// `disable_boinc_manager_autostart`.
+///
+/// `expected_dirs` is the list of directories where the matching kind of
+/// autostart entry can legitimately live; the path's immediate parent
+/// must equal one of them. `filename_ok` is the same name matcher that
+/// `detect_boinc_manager_autostart` used to find the file in the first place.
+///
+/// In `cfg(test)` the directory check is skipped so unit tests can operate
+/// on `tempfile::tempdir()` without needing root-writable mock paths; the
+/// filename matcher still runs.
+#[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows", test))]
+fn validate_autostart_path(
+    path: &std::path::Path,
+    expected_dirs: &[std::path::PathBuf],
+    filename_ok: impl Fn(&str) -> bool,
+) -> Result<(), String> {
+    let filename = path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .ok_or_else(|| "autostart path has no filename".to_string())?;
+    if !filename_ok(filename) {
+        return Err(format!(
+            "{filename} does not match a BOINC Manager autostart entry"
+        ));
+    }
+    #[cfg(not(test))]
+    {
+        let parent = path
+            .parent()
+            .ok_or_else(|| "autostart path has no parent directory".to_string())?;
+        if !expected_dirs.iter().any(|d| d == parent) {
+            return Err(format!(
+                "{} is not in an expected autostart directory",
+                path.display()
+            ));
+        }
+    }
+    #[cfg(test)]
+    {
+        let _ = expected_dirs;
+    }
+    Ok(())
+}
+
+/// Rename `path` to `path + ".fresco-disabled"`, replacing any existing
+/// disabled file from a previous run.
+#[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows", test))]
+fn rename_with_disabled_suffix(path: &std::path::Path) -> std::io::Result<std::path::PathBuf> {
+    let mut new_name = path.file_name().unwrap_or_default().to_os_string();
+    new_name.push(".fresco-disabled");
+    let dest = path.with_file_name(new_name);
+    if dest.exists() {
+        std::fs::remove_file(&dest)?;
+    }
+    std::fs::rename(path, &dest)?;
+    Ok(dest)
+}
+
+#[tauri::command]
+fn disable_boinc_manager_autostart(info: ManagerAutostartInfo) -> Result<(), String> {
+    match info {
+        ManagerAutostartInfo::MacLaunchAgent { plist_path } => {
+            #[cfg(target_os = "macos")]
+            {
+                let path = std::path::Path::new(&plist_path);
+                validate_autostart_path(path, &mac_launchagent_dirs(), is_manager_plist_name)?;
+                // Best-effort unload — ignore errors because the agent may not
+                // be currently loaded (e.g. the user just installed Manager
+                // and hasn't rebooted yet).
+                let _ = std::process::Command::new("launchctl")
+                    .args(["unload", &plist_path])
+                    .output();
+                rename_with_disabled_suffix(path)
+                    .map_err(|e| format!("Failed to rename {plist_path}: {e}"))?;
+                Ok(())
+            }
+            #[cfg(not(target_os = "macos"))]
+            {
+                let _ = plist_path;
+                Err("MacLaunchAgent only valid on macOS".to_string())
+            }
+        }
+        ManagerAutostartInfo::MacLoginItem => {
+            // Login Items registered via SMAppService are opaque to third-party
+            // apps. Signal the frontend to deep-link the user to System Settings.
+            Err("manual".to_string())
+        }
+        ManagerAutostartInfo::WindowsRunKey { hive, value_name } => {
+            #[cfg(target_os = "windows")]
+            {
+                use winreg::enums::*;
+                use winreg::types::FromRegValue;
+                use winreg::RegKey;
+                let hkey = match hive.as_str() {
+                    "HKCU" => HKEY_CURRENT_USER,
+                    "HKLM" => HKEY_LOCAL_MACHINE,
+                    other => return Err(format!("Unknown hive: {other}")),
+                };
+                let root = RegKey::predef(hkey);
+                // Editing HKLM almost always requires admin. Map permission
+                // failures on any HKLM op to the "manual" sentinel so the
+                // frontend shows an instructional fallback instead of a
+                // generic error toast.
+                let map_permission =
+                    |err: std::io::Error| -> String {
+                        if hive == "HKLM"
+                            && err.kind() == std::io::ErrorKind::PermissionDenied
+                        {
+                            "manual".to_string()
+                        } else {
+                            err.to_string()
+                        }
+                    };
+                let run = root
+                    .open_subkey_with_flags(
+                        r"Software\Microsoft\Windows\CurrentVersion\Run",
+                        KEY_QUERY_VALUE | KEY_SET_VALUE,
+                    )
+                    .map_err(|e| {
+                        let msg = map_permission(e);
+                        if msg == "manual" {
+                            msg
+                        } else {
+                            format!("Open Run key: {msg}")
+                        }
+                    })?;
+                // Re-read the value and confirm it still points at BOINC
+                // Manager before deleting — guards against the frontend
+                // asking us to delete an arbitrary Run key entry.
+                let value = run
+                    .get_raw_value(&value_name)
+                    .map_err(|e| format!("Read value {value_name}: {e}"))?;
+                if !matches!(value.vtype, REG_SZ | REG_EXPAND_SZ) {
+                    return Err(format!(
+                        "{value_name} is not a string value; refusing to delete"
+                    ));
+                }
+                let data = String::from_reg_value(&value)
+                    .map_err(|e| format!("Decode value {value_name}: {e}"))?;
+                if !data.to_ascii_lowercase().contains("boincmgr") {
+                    return Err(format!(
+                        "{value_name} does not reference boincmgr; refusing to delete"
+                    ));
+                }
+                run.delete_value(&value_name).map_err(|e| {
+                    let msg = map_permission(e);
+                    if msg == "manual" {
+                        msg
+                    } else {
+                        format!("Delete value {value_name}: {msg}")
+                    }
+                })?;
+                Ok(())
+            }
+            #[cfg(not(target_os = "windows"))]
+            {
+                let _ = (hive, value_name);
+                Err("WindowsRunKey only valid on Windows".to_string())
+            }
+        }
+        ManagerAutostartInfo::WindowsStartupShortcut { lnk_path } => {
+            #[cfg(target_os = "windows")]
+            {
+                let path = std::path::Path::new(&lnk_path);
+                let startup_dirs = std::env::var_os("APPDATA")
+                    .map(|appdata| {
+                        vec![std::path::PathBuf::from(appdata)
+                            .join(r"Microsoft\Windows\Start Menu\Programs\Startup")]
+                    })
+                    .unwrap_or_default();
+                validate_autostart_path(path, &startup_dirs, |name| {
+                    let lower = name.to_ascii_lowercase();
+                    lower.ends_with(".lnk")
+                        && (lower.contains("boincmgr") || lower.contains("boinc manager"))
+                        && !lower.ends_with(".fresco-disabled")
+                })?;
+                rename_with_disabled_suffix(path)
+                    .map_err(|e| format!("Failed to rename {lnk_path}: {e}"))?;
+                Ok(())
+            }
+            #[cfg(not(target_os = "windows"))]
+            {
+                let _ = lnk_path;
+                Err("WindowsStartupShortcut only valid on Windows".to_string())
+            }
+        }
+        ManagerAutostartInfo::LinuxAutostart { desktop_path, system_wide } => {
+            if system_wide {
+                // We can't rename files under /etc/xdg/autostart without root.
+                // Ask the frontend to show instructions.
+                return Err("manual".to_string());
+            }
+            let path = std::path::Path::new(&desktop_path);
+            #[cfg(target_os = "linux")]
+            let dirs: Vec<std::path::PathBuf> = linux_autostart_dirs()
+                .into_iter()
+                .filter(|(_, sys)| !*sys)
+                .map(|(d, _)| d)
+                .collect();
+            #[cfg(not(target_os = "linux"))]
+            let dirs: Vec<std::path::PathBuf> = Vec::new();
+            validate_autostart_path(path, &dirs, is_manager_desktop_name)?;
+            rename_with_disabled_suffix(path)
+                .map_err(|e| format!("Failed to rename {desktop_path}: {e}"))?;
+            Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod manager_autostart_tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn plist_name_matcher_accepts_official_and_rejects_client() {
+        assert!(is_manager_plist_name("edu.berkeley.boinc.Manager.plist"));
+        assert!(is_manager_plist_name("edu.berkeley.BOINCManager.plist"));
+        assert!(is_manager_plist_name("com.example.BoincManager.plist"));
+
+        // Critical: must not match the client daemon.
+        assert!(!is_manager_plist_name("edu.berkeley.boinc.plist"));
+        assert!(!is_manager_plist_name("edu.berkeley.boinc-client.plist"));
+
+        // Previously-disabled files are ignored so re-runs don't loop.
+        assert!(!is_manager_plist_name(
+            "edu.berkeley.boinc.Manager.plist.fresco-disabled"
+        ));
+        assert!(!is_manager_plist_name("unrelated.plist"));
+    }
+
+    #[test]
+    fn desktop_name_matcher_accepts_manager_variants() {
+        assert!(is_manager_desktop_name("boincmgr.desktop"));
+        assert!(is_manager_desktop_name("boinc-manager.desktop"));
+        assert!(is_manager_desktop_name("BOINCMgr.desktop"));
+        assert!(!is_manager_desktop_name("boincmgr.desktop.fresco-disabled"));
+        assert!(!is_manager_desktop_name("firefox.desktop"));
+        assert!(!is_manager_desktop_name("boincmgr.txt"));
+    }
+
+    #[test]
+    fn find_first_matching_file_returns_match_and_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(tmp.path().join("noise.plist"), b"").unwrap();
+        fs::write(tmp.path().join("edu.berkeley.boinc.Manager.plist"), b"").unwrap();
+
+        let found = find_first_matching_file(
+            &[tmp.path().to_path_buf()],
+            is_manager_plist_name,
+        );
+        assert!(found.is_some());
+        assert!(found.unwrap().to_string_lossy().ends_with("Manager.plist"));
+
+        let empty = tempfile::tempdir().unwrap();
+        assert!(find_first_matching_file(
+            &[empty.path().to_path_buf()],
+            is_manager_plist_name,
+        ).is_none());
+    }
+
+    #[test]
+    fn find_first_matching_skips_missing_dirs() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(tmp.path().join("boinc-manager.desktop"), b"").unwrap();
+
+        let mut dirs = vec![std::path::PathBuf::from("/nonexistent/does/not/exist")];
+        dirs.push(tmp.path().to_path_buf());
+
+        let found = find_first_matching_file(&dirs, is_manager_desktop_name);
+        assert!(found.is_some());
+    }
+
+    #[test]
+    fn rename_with_disabled_suffix_renames_and_overwrites() {
+        let tmp = tempfile::tempdir().unwrap();
+        let original = tmp.path().join("boincmgr.desktop");
+        fs::write(&original, b"first").unwrap();
+
+        let disabled = rename_with_disabled_suffix(&original).unwrap();
+        assert!(!original.exists());
+        assert!(disabled.exists());
+        assert_eq!(fs::read(&disabled).unwrap(), b"first");
+
+        // A second disable on a fresh file must overwrite the leftover.
+        fs::write(&original, b"second").unwrap();
+        let disabled2 = rename_with_disabled_suffix(&original).unwrap();
+        assert_eq!(disabled, disabled2);
+        assert_eq!(fs::read(&disabled2).unwrap(), b"second");
+    }
+
+    #[test]
+    fn validate_autostart_path_rejects_mismatched_filename() {
+        let tmp = tempfile::tempdir().unwrap();
+        let bogus = tmp.path().join("important_user_file.plist");
+        let err = validate_autostart_path(&bogus, &[tmp.path().to_path_buf()], is_manager_plist_name)
+            .unwrap_err();
+        assert!(err.contains("does not match"));
+    }
+
+    #[test]
+    fn validate_autostart_path_accepts_matching_filename() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("edu.berkeley.boinc.Manager.plist");
+        validate_autostart_path(&path, &[tmp.path().to_path_buf()], is_manager_plist_name).unwrap();
+    }
+
+    #[test]
+    fn disable_rejects_mac_launch_agent_with_mismatched_filename() {
+        let tmp = tempfile::tempdir().unwrap();
+        let bogus = tmp.path().join("unrelated.plist");
+        #[cfg(target_os = "macos")]
+        std::fs::write(&bogus, b"").unwrap();
+        let err = disable_boinc_manager_autostart(ManagerAutostartInfo::MacLaunchAgent {
+            plist_path: bogus.to_string_lossy().into_owned(),
+        })
+        .unwrap_err();
+        // Either the filename-matcher rejects (macOS) or the "only valid on
+        // macOS" sentinel trips (non-macOS); both indicate we didn't rename.
+        assert!(err.contains("does not match") || err.contains("only valid on macOS"));
+    }
+
+    #[test]
+    fn disable_rejects_mac_login_item_with_manual_sentinel() {
+        // Frontend keys off the literal "manual" string to fall back to
+        // deep-linking System Settings, so this contract must not drift.
+        let err = disable_boinc_manager_autostart(ManagerAutostartInfo::MacLoginItem)
+            .unwrap_err();
+        assert_eq!(err, "manual");
+    }
+
+    #[test]
+    fn disable_rejects_system_wide_linux_autostart_with_manual_sentinel() {
+        let err = disable_boinc_manager_autostart(ManagerAutostartInfo::LinuxAutostart {
+            desktop_path: "/etc/xdg/autostart/boincmgr.desktop".into(),
+            system_wide: true,
+        })
+        .unwrap_err();
+        assert_eq!(err, "manual");
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn disable_user_linux_autostart_renames_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("boinc-manager.desktop");
+        std::fs::write(&path, b"[Desktop Entry]\n").unwrap();
+
+        disable_boinc_manager_autostart(ManagerAutostartInfo::LinuxAutostart {
+            desktop_path: path.to_string_lossy().into_owned(),
+            system_wide: false,
+        })
+        .unwrap();
+
+        assert!(!path.exists());
+        assert!(path.with_file_name("boinc-manager.desktop.fresco-disabled").exists());
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn disable_mac_launch_agent_renames_plist() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("edu.berkeley.boinc.Manager.plist");
+        std::fs::write(&path, b"<plist/>").unwrap();
+
+        disable_boinc_manager_autostart(ManagerAutostartInfo::MacLaunchAgent {
+            plist_path: path.to_string_lossy().into_owned(),
+        })
+        .unwrap();
+
+        assert!(!path.exists());
+        assert!(path
+            .with_file_name("edu.berkeley.boinc.Manager.plist.fresco-disabled")
+            .exists());
+    }
+}
+
+#[cfg(test)]
+mod install_options_tests {
+    use super::*;
+
+    #[test]
+    fn install_options_reports_current_platform() {
+        let opts = detect_boinc_install_options();
+        let expected = if cfg!(target_os = "windows") {
+            "windows"
+        } else if cfg!(target_os = "macos") {
+            "macos"
+        } else {
+            "linux"
+        };
+        assert_eq!(opts.platform, expected);
+    }
+
+    #[test]
+    fn install_options_boinc_present_matches_resolver() {
+        let opts = detect_boinc_install_options();
+        assert_eq!(opts.boinc_present, resolve_boinc_exe("").is_ok());
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn install_options_windows_has_empty_pm_list() {
+        let opts = detect_boinc_install_options();
+        assert!(opts.package_managers.is_empty());
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    #[tokio::test]
+    async fn install_boinc_via_brew_errors_on_non_macos() {
+        let err = install_boinc_via_brew().await.unwrap_err();
+        assert_eq!(err, "macOS-only");
+    }
+}
+
+#[tauri::command]
+fn open_login_items_settings() -> Result<(), String> {
+    #[cfg(target_os = "macos")]
+    {
+        std::process::Command::new("open")
+            .arg("x-apple.systempreferences:com.apple.LoginItems-Settings.extension")
+            .spawn()
+            .map_err(|e| format!("Failed to open System Settings: {e}"))?;
+        Ok(())
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        Err("open_login_items_settings is macOS-only".to_string())
     }
 }
 
@@ -1098,6 +1840,11 @@ pub fn run() {
             get_newer_version,
             start_boinc_client,
             detect_boinc_client_dir,
+            detect_boinc_install_options,
+            install_boinc_via_brew,
+            detect_boinc_manager_autostart,
+            disable_boinc_manager_autostart,
+            open_login_items_settings,
             launch_graphics,
             launch_remote_desktop,
             exchange_versions,

--- a/src-tauri/src/rpc/xml_parse.rs
+++ b/src-tauri/src/rpc/xml_parse.rs
@@ -1206,10 +1206,10 @@ pub fn parse_host_info(xml: &str) -> HostInfo {
                                     current_coproc.driver_version = format!("{major}.{minor:02}");
                                 }
                             }
-                            "driver_version" | "display_driver_version" => {
-                                if current_coproc.driver_version.is_empty() {
-                                    current_coproc.driver_version = text;
-                                }
+                            "driver_version" | "display_driver_version"
+                                if current_coproc.driver_version.is_empty() =>
+                            {
+                                current_coproc.driver_version = text;
                             }
                             // CUDA XML uses cudaVersion
                             "cudaVersion" | "cuda_version" => {
@@ -1295,17 +1295,13 @@ pub fn parse_host_info(xml: &str) -> HostInfo {
             Ok(Event::End(ref e)) => {
                 let tag = String::from_utf8_lossy(e.name().as_ref()).to_string();
                 match tag.as_str() {
-                    "coproc_cuda" | "coproc_opencl" => {
-                        if in_coproc {
-                            info.coprocs.push(current_coproc.clone());
-                            in_coproc = false;
-                        }
+                    "coproc_cuda" | "coproc_opencl" if in_coproc => {
+                        info.coprocs.push(current_coproc.clone());
+                        in_coproc = false;
                     }
-                    "distro" => {
-                        if in_distro {
-                            info.wsl_distros.push(current_distro.clone());
-                            in_distro = false;
-                        }
+                    "distro" if in_distro => {
+                        info.wsl_distros.push(current_distro.clone());
+                        in_distro = false;
                     }
                     "wsl" => {
                         in_wsl = false;

--- a/src/App.vue
+++ b/src/App.vue
@@ -32,6 +32,10 @@ import { useNoticesStore } from "./stores/notices";
 import { useDiskUsageStore } from "./stores/diskUsage";
 import { usePreferencesStore } from "./stores/preferences";
 import { useManagerSettingsStore } from "./stores/managerSettings";
+import { useToastStore } from "./stores/toast";
+import OnboardingTakeoverDialog from "./components/OnboardingTakeoverDialog.vue";
+import BoincInstallDialog from "./components/BoincInstallDialog.vue";
+import type { ManagerAutostartInfo, BoincInstallOptions } from "./types/boinc";
 import {
   setRunMode,
   setGpuMode,
@@ -53,7 +57,8 @@ const messagesStore = useMessagesStore();
 const noticesStore = useNoticesStore();
 const diskUsageStore = useDiskUsageStore();
 const preferencesStore = usePreferencesStore();
-useManagerSettingsStore(); // Initialize early to apply theme before ConnectView renders
+const managerSettingsStore = useManagerSettingsStore(); // Initialize early to apply theme before ConnectView renders
+const toastStore = useToastStore();
 const showPreferences = ref(false);
 const showAbout = ref(false);
 const showSelectComputer = ref(false);
@@ -175,12 +180,238 @@ async function autoConnect() {
   if (connection.state === CONNECTION_STATE.CONNECTED) {
     startAllPolling();
     router.push("/tasks");
+    // Flip out of the loading screen BEFORE awaiting onboarding —
+    // the dialog is mounted only inside the v-else branch, so leaving
+    // `initializing` true would mean the dialog never renders and the
+    // await below would hang the startup flow forever.
+    initializing.value = false;
+    await runOnboardingIfNeeded();
     invoke("cleanup_old_binary").catch(() => {});
-  } else {
-    // Auto-connect failed — show ConnectView
-    router.replace("/");
+    return;
   }
+
+  // Auto-connect failed. If the binary is missing, give the user a chance
+  // to install it; the install-onboarding dialog lives in the v-else branch
+  // so we must clear `initializing` before awaiting it (same reason as above).
   initializing.value = false;
+  if (autoConnectCancelled) return;
+
+  const recovered = await runInstallOnboardingIfNeeded(dataDir);
+  if (autoConnectCancelled) return;
+
+  if (recovered) {
+    startAllPolling();
+    router.push("/tasks");
+    await runOnboardingIfNeeded();
+    invoke("cleanup_old_binary").catch(() => {});
+    return;
+  }
+
+  router.replace("/");
+}
+
+// Tauri v2 rejects a command with either `Error: <msg>` or a named
+// `InvokeError: <msg>` prefix depending on how the error is constructed.
+// Normalize both shapes before comparing against sentinels like "manual".
+function errMessage(err: unknown): string {
+  const raw = err instanceof Error ? err.message : String(err);
+  return raw.replace(/^(?:[A-Za-z]\w*Error|Error):\s*/, "").trim();
+}
+
+// ── BOINC install onboarding (no binary) ────────────────────────
+
+type InstallChoice = "install-succeeded" | "skip";
+
+const installOptions = ref<BoincInstallOptions | null>(null);
+const showInstallDialog = ref(false);
+const installing = ref(false);
+let installResolver: ((choice: InstallChoice) => void) | null = null;
+
+async function runInstallOnboardingIfNeeded(dataDir: string): Promise<boolean> {
+  if (managerSettingsStore.settings.installOnboardingCompleted) return false;
+
+  let opts: BoincInstallOptions | undefined;
+  try {
+    opts = await invoke("detect_boinc_install_options");
+  } catch {
+    // Detection failure shouldn't block startup — fall through to ConnectView.
+    return false;
+  }
+
+  if (!opts || opts.boinc_present) {
+    // Binary exists but we still couldn't connect — not an install problem.
+    return false;
+  }
+
+  installOptions.value = opts;
+  showInstallDialog.value = true;
+  loadingStatus.value = "";
+
+  const choice = await new Promise<InstallChoice>((resolve) => {
+    installResolver = resolve;
+  });
+  installResolver = null;
+  showInstallDialog.value = false;
+  installOptions.value = null;
+  managerSettingsStore.settings.installOnboardingCompleted = true;
+
+  if (choice !== "install-succeeded") return false;
+
+  try {
+    await connection.connectToLocal(dataDir);
+  } catch {
+    return false;
+  }
+  return connection.state === CONNECTION_STATE.CONNECTED;
+}
+
+async function handleInstallBrew() {
+  const dataDir = defaultDataDir(await getOS());
+  installing.value = true;
+  try {
+    await invoke("install_boinc_via_brew");
+    try {
+      await startBoincClient(dataDir);
+    } catch (err) {
+      const msg = errMessage(err).slice(0, 200);
+      toastStore.show(
+        msg || t("onboarding.install.brewError"),
+        "error",
+        8000,
+      );
+      installResolver?.("skip");
+      return;
+    }
+    installResolver?.("install-succeeded");
+  } catch (err) {
+    const msg = errMessage(err).slice(0, 200);
+    toastStore.show(
+      msg || t("onboarding.install.brewError"),
+      "error",
+      8000,
+    );
+    installResolver?.("skip");
+  } finally {
+    installing.value = false;
+  }
+}
+
+async function handleCopyCommand(cmd: string) {
+  try {
+    await navigator.clipboard.writeText(cmd);
+    toastStore.show(t("onboarding.install.copied"), "success");
+  } catch {
+    // Clipboard unavailable (e.g. insecure origin) — ignore silently; the
+    // command is still visible in the dialog for manual copy.
+  }
+}
+
+async function handleOpenUrl(url: string) {
+  try {
+    const { openUrl } = await import("@tauri-apps/plugin-opener");
+    await openUrl(url);
+  } catch {
+    window.open(url, "_blank");
+  }
+  installResolver?.("skip");
+}
+
+function handleSkipInstall() {
+  installResolver?.("skip");
+}
+
+// ── BOINC Manager takeover onboarding ───────────────────────────
+
+const onboardingInfo = ref<ManagerAutostartInfo | null>(null);
+const showOnboarding = ref(false);
+let onboardingResolver: (() => void) | null = null;
+
+async function runOnboardingIfNeeded() {
+  if (managerSettingsStore.settings.onboardingCompleted) return;
+
+  let info: ManagerAutostartInfo | null = null;
+  try {
+    info = await invoke("detect_boinc_manager_autostart");
+  } catch {
+    // Detection is best-effort — a failure shouldn't block the app.
+    managerSettingsStore.settings.onboardingCompleted = true;
+    return;
+  }
+
+  if (!info) {
+    managerSettingsStore.settings.onboardingCompleted = true;
+    return;
+  }
+
+  onboardingInfo.value = info;
+  showOnboarding.value = true;
+  loadingStatus.value = "";
+
+  await new Promise<void>((resolve) => {
+    onboardingResolver = resolve;
+  });
+  onboardingResolver = null;
+  managerSettingsStore.settings.onboardingCompleted = true;
+}
+
+async function handleTakeover() {
+  const info = onboardingInfo.value;
+  showOnboarding.value = false;
+  if (!info) {
+    onboardingResolver?.();
+    return;
+  }
+  try {
+    await invoke("disable_boinc_manager_autostart", { info });
+    toastStore.show(t("onboarding.takeover.successToast"), "success");
+  } catch (err) {
+    const message = errMessage(err);
+    if (message === "manual") {
+      if (info.kind === "MacLoginItem") {
+        // macOS SMAppService Login Items can't be toggled by third-party apps;
+        // point the user at the exact System Settings pane.
+        try {
+          await invoke("open_login_items_settings");
+        } catch {
+          // Ignore — the instructional toast still points the user at the setting.
+        }
+        toastStore.show(t("onboarding.takeover.manualToast"), "info", 8000);
+      } else if (
+        info.kind === "LinuxAutostart" &&
+        info.data.system_wide
+      ) {
+        // /etc/xdg/autostart can only be edited with root; show the path.
+        toastStore.show(
+          t("onboarding.takeover.linuxManualToast", {
+            path: info.data.desktop_path,
+          }),
+          "info",
+          10000,
+        );
+      } else if (info.kind === "WindowsRunKey" && info.data.hive === "HKLM") {
+        // HKLM\...\Run requires admin to delete. Rather than a cryptic
+        // permission-denied toast, point the user at the entry they need
+        // to remove manually (or re-run Fresco elevated).
+        toastStore.show(
+          t("onboarding.takeover.windowsHklmManualToast", {
+            valueName: info.data.value_name,
+          }),
+          "info",
+          10000,
+        );
+      } else {
+        toastStore.show(t("onboarding.takeover.errorToast"), "error");
+      }
+    } else {
+      toastStore.show(t("onboarding.takeover.errorToast"), "error");
+    }
+  }
+  onboardingResolver?.();
+}
+
+function handleKeepBoth() {
+  showOnboarding.value = false;
+  onboardingResolver?.();
 }
 
 function cancelAutoConnect() {
@@ -578,6 +809,22 @@ watch(
       v-if="showAcctMgr"
       :open="showAcctMgr"
       @close="showAcctMgr = false"
+    />
+    <OnboardingTakeoverDialog
+      :open="showOnboarding"
+      :info="onboardingInfo"
+      @takeover="handleTakeover"
+      @keep-both="handleKeepBoth"
+    />
+    <BoincInstallDialog
+      v-if="installOptions"
+      :open="showInstallDialog"
+      :options="installOptions"
+      :installing="installing"
+      @install="handleInstallBrew"
+      @skip="handleSkipInstall"
+      @copy-command="handleCopyCommand"
+      @open-url="handleOpenUrl"
     />
     <ToastContainer />
   </div>

--- a/src/components/BoincInstallDialog.test.ts
+++ b/src/components/BoincInstallDialog.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mount, type VueWrapper } from "@vue/test-utils";
+import BoincInstallDialog from "./BoincInstallDialog.vue";
+import type { BoincInstallOptions } from "../types/boinc";
+
+vi.mock("@vueuse/integrations/useFocusTrap", () => ({
+  useFocusTrap: () => ({
+    activate: vi.fn(),
+    deactivate: vi.fn(),
+  }),
+}));
+
+const DOWNLOAD_URL = "https://boinc.berkeley.edu/download.php";
+
+function macosBrewOptions(): BoincInstallOptions {
+  return {
+    boinc_present: false,
+    platform: "macos",
+    package_managers: ["brew"],
+    official_download_url: DOWNLOAD_URL,
+  };
+}
+
+function linuxAptOptions(): BoincInstallOptions {
+  return {
+    boinc_present: false,
+    platform: "linux",
+    package_managers: ["apt"],
+    official_download_url: DOWNLOAD_URL,
+  };
+}
+
+function windowsOptions(): BoincInstallOptions {
+  return {
+    boinc_present: false,
+    platform: "windows",
+    package_managers: [],
+    official_download_url: DOWNLOAD_URL,
+  };
+}
+
+function clearBody() {
+  document.body.replaceChildren();
+}
+
+let mountedWrappers: VueWrapper<unknown>[] = [];
+
+function mountDialog(options: BoincInstallOptions, installing = false) {
+  const wrapper = mount(BoincInstallDialog, {
+    props: { open: true, options, installing },
+    global: {
+      mocks: {
+        $t: (key: string) => key,
+      },
+    },
+  });
+  mountedWrappers.push(wrapper);
+  return wrapper;
+}
+
+describe("BoincInstallDialog", () => {
+  beforeEach(() => {
+    clearBody();
+  });
+
+  afterEach(() => {
+    // Tear down every wrapper mounted in the test so the global Escape
+    // keystroke listener registered by `onKeyStroke` is removed; otherwise
+    // listeners accumulate across tests and one Escape fires many handlers.
+    mountedWrappers.forEach((w) => w.unmount());
+    mountedWrappers = [];
+  });
+
+  it("does not render when closed", () => {
+    const wrapper = mount(BoincInstallDialog, {
+      props: { open: false, options: macosBrewOptions(), installing: false },
+      global: { mocks: { $t: (k: string) => k } },
+    });
+    mountedWrappers.push(wrapper);
+    expect(document.body.querySelector(".dialog-overlay")).toBeNull();
+  });
+
+  it("macOS+brew: emits install when the brew button is clicked", async () => {
+    const wrapper = mountDialog(macosBrewOptions());
+    const btn = document.body.querySelector(
+      '[data-testid="brew-install-btn"]',
+    ) as HTMLElement;
+    expect(btn).not.toBeNull();
+    btn.click();
+    await wrapper.vm.$nextTick();
+    expect(wrapper.emitted("install")).toBeTruthy();
+  });
+
+  it("macOS+brew: brew button is disabled while installing", () => {
+    mountDialog(macosBrewOptions(), true);
+    const btn = document.body.querySelector(
+      '[data-testid="brew-install-btn"]',
+    ) as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
+    expect(
+      document.body.querySelector('[data-testid="brew-progress"]'),
+    ).not.toBeNull();
+  });
+
+  it("Linux+apt: emits copyCommand with the apt command", async () => {
+    const wrapper = mountDialog(linuxAptOptions());
+    const pre = document.body.querySelector(
+      '[data-testid="linux-primary-command"]',
+    ) as HTMLElement;
+    expect(pre.textContent).toContain("sudo apt install boinc-client");
+    const copyBtn = document.body.querySelector(
+      '[data-testid="linux-copy-btn"]',
+    ) as HTMLElement;
+    copyBtn.click();
+    await wrapper.vm.$nextTick();
+    const emitted = wrapper.emitted("copyCommand");
+    expect(emitted).toBeTruthy();
+    expect(emitted?.[0]).toEqual(["sudo apt install boinc-client"]);
+  });
+
+  it("Windows: emits openUrl with the download URL", async () => {
+    const wrapper = mountDialog(windowsOptions());
+    const btn = document.body.querySelector(
+      '[data-testid="download-btn"]',
+    ) as HTMLElement;
+    expect(btn).not.toBeNull();
+    btn.click();
+    await wrapper.vm.$nextTick();
+    const emitted = wrapper.emitted("openUrl");
+    expect(emitted).toBeTruthy();
+    expect(emitted?.[0]).toEqual([DOWNLOAD_URL]);
+  });
+
+  it("emits skip on Escape", async () => {
+    const wrapper = mount(BoincInstallDialog, {
+      props: { open: false, options: macosBrewOptions(), installing: false },
+      global: { mocks: { $t: (k: string) => k } },
+    });
+    mountedWrappers.push(wrapper);
+    await wrapper.setProps({ open: true });
+    await wrapper.vm.$nextTick();
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    await wrapper.vm.$nextTick();
+    expect(wrapper.emitted("skip")).toBeTruthy();
+  });
+
+  it("emits skip when the Skip button is clicked", async () => {
+    const wrapper = mountDialog(macosBrewOptions());
+    const btn = document.body.querySelector(
+      '[data-testid="skip-btn"]',
+    ) as HTMLElement;
+    btn.click();
+    await wrapper.vm.$nextTick();
+    expect(wrapper.emitted("skip")).toBeTruthy();
+  });
+
+  it("Skip is disabled while installing (prevents racing brew)", () => {
+    mountDialog(macosBrewOptions(), true);
+    const btn = document.body.querySelector(
+      '[data-testid="skip-btn"]',
+    ) as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
+  });
+});

--- a/src/components/BoincInstallDialog.vue
+++ b/src/components/BoincInstallDialog.vue
@@ -1,0 +1,335 @@
+<script setup lang="ts">
+import { computed, nextTick, ref, watch } from "vue";
+import { onKeyStroke } from "@vueuse/core";
+import { useFocusTrap } from "@vueuse/integrations/useFocusTrap";
+import type { BoincInstallOptions } from "../types/boinc";
+
+const props = defineProps<{
+  open: boolean;
+  options: BoincInstallOptions;
+  installing: boolean;
+}>();
+
+const emit = defineEmits<{
+  install: [];
+  skip: [];
+  copyCommand: [cmd: string];
+  openUrl: [url: string];
+}>();
+
+const dialogRef = ref<HTMLElement | null>(null);
+const { activate, deactivate } = useFocusTrap(dialogRef);
+const showMorePMs = ref(false);
+
+watch(
+  () => props.open,
+  async (isOpen) => {
+    if (isOpen) {
+      await nextTick();
+      if (!props.open) return;
+      activate();
+    } else {
+      deactivate();
+      showMorePMs.value = false;
+    }
+  },
+  // `immediate: true` — the dialog is mounted via `v-if="installOptions"`
+  // with `open=true` already set in the same tick, so a plain watcher
+  // would never see the false→true transition and the focus trap would
+  // never activate on first render.
+  { immediate: true },
+);
+
+// Escape skips the dialog — the user can still install manually.
+onKeyStroke("Escape", () => {
+  if (!props.open) return;
+  if (props.installing) return;
+  emit("skip");
+});
+
+const PM_COMMANDS: Record<string, string> = {
+  apt: "sudo apt install boinc-client",
+  dnf: "sudo dnf install boinc-client",
+  pacman: "sudo pacman -S boinc",
+};
+
+const hasBrew = computed(() =>
+  props.options.platform === "macos"
+    && props.options.package_managers.includes("brew"),
+);
+
+const linuxPMs = computed(() =>
+  props.options.platform === "linux"
+    ? props.options.package_managers.filter((pm) => pm in PM_COMMANDS)
+    : [],
+);
+
+const primaryCommand = computed(() => {
+  const pm = linuxPMs.value[0];
+  return pm ? PM_COMMANDS[pm] : "";
+});
+
+const extraCommands = computed(() =>
+  linuxPMs.value.slice(1).map((pm) => PM_COMMANDS[pm]),
+);
+
+function handleInstallClick() {
+  if (props.installing) return;
+  emit("install");
+}
+
+function handleCopyPrimary() {
+  if (primaryCommand.value) emit("copyCommand", primaryCommand.value);
+}
+
+function handleCopyExtra(cmd: string) {
+  emit("copyCommand", cmd);
+}
+
+function handleDownloadClick() {
+  emit("openUrl", props.options.official_download_url);
+}
+
+function handleOverlayClick() {
+  if (props.installing) return;
+  emit("skip");
+}
+</script>
+
+<template>
+  <Teleport to="body">
+    <div v-if="open" class="dialog-overlay" @click.self="handleOverlayClick">
+      <div
+        ref="dialogRef"
+        class="onboarding-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="onboarding-install-title"
+        aria-describedby="onboarding-install-body"
+      >
+        <div class="onboarding-header">
+          <h3 id="onboarding-install-title">
+            {{ $t("onboarding.install.title") }}
+          </h3>
+        </div>
+
+        <div id="onboarding-install-body" class="onboarding-body">
+          <p>{{ $t("onboarding.install.lead") }}</p>
+
+          <!-- macOS + Homebrew -->
+          <template v-if="hasBrew">
+            <p
+              v-if="installing"
+              class="install-progress"
+              data-testid="brew-progress"
+            >
+              {{ $t("onboarding.install.brewInProgress") }}
+            </p>
+          </template>
+
+          <!-- macOS without brew -->
+          <template v-else-if="options.platform === 'macos'">
+            <p class="explanation">
+              {{ $t("onboarding.install.macosNoBrewLead") }}
+            </p>
+          </template>
+
+          <!-- Linux -->
+          <template v-else-if="options.platform === 'linux'">
+            <p class="explanation">
+              {{ $t("onboarding.install.linuxLead") }}
+            </p>
+            <div v-if="primaryCommand" class="command-block">
+              <pre data-testid="linux-primary-command">{{ primaryCommand }}</pre>
+              <button
+                class="btn btn-small"
+                data-testid="linux-copy-btn"
+                @click="handleCopyPrimary"
+              >
+                {{ $t("onboarding.install.linuxCopyButton") }}
+              </button>
+            </div>
+            <div v-if="extraCommands.length > 0" class="extra-pms">
+              <button
+                class="btn-link"
+                type="button"
+                @click="showMorePMs = !showMorePMs"
+              >
+                {{ showMorePMs ? "▾" : "▸" }}
+                {{ $t("onboarding.install.showMore") }}
+              </button>
+              <div v-if="showMorePMs">
+                <div
+                  v-for="cmd in extraCommands"
+                  :key="cmd"
+                  class="command-block"
+                >
+                  <pre>{{ cmd }}</pre>
+                  <button
+                    class="btn btn-small"
+                    @click="handleCopyExtra(cmd)"
+                  >
+                    {{ $t("onboarding.install.linuxCopyButton") }}
+                  </button>
+                </div>
+              </div>
+            </div>
+            <p v-if="!primaryCommand" class="explanation">
+              {{ $t("onboarding.install.linuxNoPmFallback") }}
+            </p>
+          </template>
+
+          <!-- Windows -->
+          <template v-else>
+            <p class="explanation">
+              {{ $t("onboarding.install.windowsLead") }}
+            </p>
+            <p class="manual-note">
+              {{ $t("onboarding.install.windowsManagerNote") }}
+            </p>
+          </template>
+        </div>
+
+        <div class="onboarding-footer">
+          <button
+            class="btn"
+            data-testid="skip-btn"
+            :disabled="installing"
+            @click="emit('skip')"
+          >
+            {{ $t("onboarding.install.skip") }}
+          </button>
+
+          <button
+            v-if="hasBrew"
+            class="btn btn-primary"
+            data-testid="brew-install-btn"
+            :disabled="installing"
+            @click="handleInstallClick"
+          >
+            {{
+              installing
+                ? $t("onboarding.install.brewInProgress")
+                : $t("onboarding.install.brewAction")
+            }}
+          </button>
+
+          <button
+            v-else-if="options.platform === 'macos' || options.platform === 'windows' || (options.platform === 'linux' && !primaryCommand)"
+            class="btn btn-primary"
+            data-testid="download-btn"
+            @click="handleDownloadClick"
+          >
+            {{ $t("onboarding.install.downloadButton") }}
+          </button>
+        </div>
+      </div>
+    </div>
+  </Teleport>
+</template>
+
+<style scoped>
+.dialog-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.3);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: var(--z-modal);
+  backdrop-filter: blur(2px);
+}
+
+.onboarding-dialog {
+  background: var(--color-bg);
+  border-radius: var(--radius-lg);
+  max-width: 520px;
+  width: 90%;
+  box-shadow: var(--shadow-lg);
+}
+
+.onboarding-header {
+  padding: var(--space-lg) var(--space-xl);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.onboarding-header h3 {
+  margin: 0;
+  font-size: var(--font-size-lg);
+  font-weight: 600;
+}
+
+.onboarding-body {
+  padding: var(--space-xl);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  color: var(--color-text-primary);
+  font-size: var(--font-size-md);
+  line-height: 1.5;
+}
+
+.onboarding-body p {
+  margin: 0;
+}
+
+.explanation {
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+}
+
+.manual-note {
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+  padding: var(--space-sm);
+  background: var(--color-bg-secondary, rgba(0, 0, 0, 0.04));
+  border-radius: var(--radius-sm);
+}
+
+.install-progress {
+  color: var(--color-text-secondary);
+  font-style: italic;
+}
+
+.command-block {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  padding: var(--space-sm);
+  background: var(--color-bg-secondary, rgba(0, 0, 0, 0.04));
+  border-radius: var(--radius-sm);
+}
+
+.command-block pre {
+  flex: 1;
+  margin: 0;
+  font-family: var(--font-mono, monospace);
+  font-size: var(--font-size-sm);
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+.extra-pms {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.btn-link {
+  background: transparent;
+  border: 0;
+  color: var(--color-accent, #0b74de);
+  cursor: pointer;
+  padding: 0;
+  align-self: flex-start;
+  font-size: var(--font-size-sm);
+}
+
+.onboarding-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-sm);
+  padding: var(--space-lg) var(--space-xl);
+  border-top: 1px solid var(--color-border);
+}
+</style>

--- a/src/components/OnboardingTakeoverDialog.test.ts
+++ b/src/components/OnboardingTakeoverDialog.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mount, type VueWrapper } from "@vue/test-utils";
+import OnboardingTakeoverDialog from "./OnboardingTakeoverDialog.vue";
+import type { ManagerAutostartInfo } from "../types/boinc";
+
+vi.mock("@vueuse/integrations/useFocusTrap", () => ({
+  useFocusTrap: () => ({
+    activate: vi.fn(),
+    deactivate: vi.fn(),
+  }),
+}));
+
+const macInfo: ManagerAutostartInfo = {
+  kind: "MacLaunchAgent",
+  data: { plist_path: "/Library/LaunchAgents/edu.berkeley.boinc.Manager.plist" },
+};
+
+function clearBody() {
+  document.body.replaceChildren();
+}
+
+let mountedWrappers: VueWrapper<unknown>[] = [];
+
+function mountDialog(
+  open: boolean,
+  info: ManagerAutostartInfo | null = macInfo,
+) {
+  const wrapper = mount(OnboardingTakeoverDialog, {
+    props: { open, info },
+    global: {
+      mocks: {
+        $t: (key: string) => key,
+      },
+    },
+  });
+  mountedWrappers.push(wrapper);
+  return wrapper;
+}
+
+describe("OnboardingTakeoverDialog", () => {
+  beforeEach(() => {
+    clearBody();
+  });
+
+  afterEach(() => {
+    // Tear down every wrapper mounted in the test so the global Escape
+    // keystroke listener registered by `onKeyStroke` is removed; otherwise
+    // listeners accumulate across tests and one Escape fires many handlers.
+    mountedWrappers.forEach((w) => w.unmount());
+    mountedWrappers = [];
+  });
+
+  it("does not render when closed", () => {
+    mountDialog(false);
+    expect(document.body.querySelector(".dialog-overlay")).toBeNull();
+  });
+
+  it("renders title and buttons when open", () => {
+    mountDialog(true);
+    const overlay = document.body.querySelector(".dialog-overlay");
+    expect(overlay).not.toBeNull();
+    expect(
+      document.body.querySelector('[data-testid="takeover-btn"]'),
+    ).not.toBeNull();
+    expect(
+      document.body.querySelector('[data-testid="keep-both-btn"]'),
+    ).not.toBeNull();
+  });
+
+  it("emits takeover when the primary button is clicked", async () => {
+    const wrapper = mountDialog(true);
+    const btn = document.body.querySelector(
+      '[data-testid="takeover-btn"]',
+    ) as HTMLElement;
+    btn.click();
+    await wrapper.vm.$nextTick();
+    expect(wrapper.emitted("takeover")).toBeTruthy();
+    expect(wrapper.emitted("keepBoth")).toBeFalsy();
+  });
+
+  it("emits keepBoth when the secondary button is clicked", async () => {
+    const wrapper = mountDialog(true);
+    const btn = document.body.querySelector(
+      '[data-testid="keep-both-btn"]',
+    ) as HTMLElement;
+    btn.click();
+    await wrapper.vm.$nextTick();
+    expect(wrapper.emitted("keepBoth")).toBeTruthy();
+    expect(wrapper.emitted("takeover")).toBeFalsy();
+  });
+
+  it("emits keepBoth on Escape", async () => {
+    const wrapper = mountDialog(false);
+    await wrapper.setProps({ open: true });
+    await wrapper.vm.$nextTick();
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    await wrapper.vm.$nextTick();
+    expect(wrapper.emitted("keepBoth")).toBeTruthy();
+  });
+
+  it("emits keepBoth when the overlay backdrop is clicked", async () => {
+    const wrapper = mountDialog(true);
+    const overlay = document.body.querySelector(
+      ".dialog-overlay",
+    ) as HTMLElement;
+    overlay.click();
+    await wrapper.vm.$nextTick();
+    expect(wrapper.emitted("keepBoth")).toBeTruthy();
+  });
+
+  it("shows the manual note only for MacLoginItem", () => {
+    mountDialog(true, macInfo);
+    expect(
+      document.body.querySelector('[data-testid="manual-note"]'),
+    ).toBeNull();
+    clearBody();
+
+    mountDialog(true, { kind: "MacLoginItem" });
+    expect(
+      document.body.querySelector('[data-testid="manual-note"]'),
+    ).not.toBeNull();
+  });
+
+  it("has correct ARIA attributes when open", () => {
+    mountDialog(true);
+    const dialog = document.body.querySelector("[role='dialog']");
+    expect(dialog).not.toBeNull();
+    expect(dialog!.getAttribute("aria-modal")).toBe("true");
+    expect(dialog!.getAttribute("aria-labelledby")).toBe(
+      "onboarding-takeover-title",
+    );
+    expect(dialog!.getAttribute("aria-describedby")).toBe(
+      "onboarding-takeover-body",
+    );
+  });
+});

--- a/src/components/OnboardingTakeoverDialog.vue
+++ b/src/components/OnboardingTakeoverDialog.vue
@@ -1,0 +1,161 @@
+<script setup lang="ts">
+import { nextTick, ref, watch, computed } from "vue";
+import { onKeyStroke } from "@vueuse/core";
+import { useFocusTrap } from "@vueuse/integrations/useFocusTrap";
+import type { ManagerAutostartInfo } from "../types/boinc";
+
+const props = defineProps<{
+  open: boolean;
+  info: ManagerAutostartInfo | null;
+}>();
+
+const emit = defineEmits<{
+  takeover: [];
+  keepBoth: [];
+}>();
+
+const dialogRef = ref<HTMLElement | null>(null);
+const { activate, deactivate } = useFocusTrap(dialogRef);
+
+watch(
+  () => props.open,
+  async (isOpen) => {
+    if (isOpen) {
+      await nextTick();
+      if (!props.open) return;
+      activate();
+    } else {
+      deactivate();
+    }
+  },
+);
+
+// Escape is intentionally treated as "Keep both" — a takeover shouldn't be
+// triggered by an accidental key press, and the prompt must resolve so
+// autoConnect can move on.
+onKeyStroke("Escape", () => {
+  if (!props.open) return;
+  emit("keepBoth");
+});
+
+const autostartKind = computed(() => props.info?.kind ?? null);
+</script>
+
+<template>
+  <Teleport to="body">
+    <div v-if="open" class="dialog-overlay" @click.self="emit('keepBoth')">
+      <div
+        ref="dialogRef"
+        class="onboarding-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="onboarding-takeover-title"
+        aria-describedby="onboarding-takeover-body"
+      >
+        <div class="onboarding-header">
+          <h3 id="onboarding-takeover-title">
+            {{ $t("onboarding.takeover.title") }}
+          </h3>
+        </div>
+
+        <div id="onboarding-takeover-body" class="onboarding-body">
+          <p>{{ $t("onboarding.takeover.lead") }}</p>
+          <p class="explanation">
+            {{ $t("onboarding.takeover.explanation") }}
+          </p>
+          <p
+            v-if="autostartKind === 'MacLoginItem'"
+            class="manual-note"
+            data-testid="manual-note"
+          >
+            {{ $t("onboarding.takeover.macLoginItemNote") }}
+          </p>
+        </div>
+
+        <div class="onboarding-footer">
+          <button
+            class="btn"
+            data-testid="keep-both-btn"
+            @click="emit('keepBoth')"
+          >
+            {{ $t("onboarding.takeover.keepBoth") }}
+          </button>
+          <button
+            class="btn btn-primary"
+            data-testid="takeover-btn"
+            @click="emit('takeover')"
+          >
+            {{ $t("onboarding.takeover.useFrescoOnly") }}
+          </button>
+        </div>
+      </div>
+    </div>
+  </Teleport>
+</template>
+
+<style scoped>
+.dialog-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.3);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: var(--z-modal);
+  backdrop-filter: blur(2px);
+}
+
+.onboarding-dialog {
+  background: var(--color-bg);
+  border-radius: var(--radius-lg);
+  max-width: 480px;
+  width: 90%;
+  box-shadow: var(--shadow-lg);
+}
+
+.onboarding-header {
+  padding: var(--space-lg) var(--space-xl);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.onboarding-header h3 {
+  margin: 0;
+  font-size: var(--font-size-lg);
+  font-weight: 600;
+}
+
+.onboarding-body {
+  padding: var(--space-xl);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  color: var(--color-text-primary);
+  font-size: var(--font-size-md);
+  line-height: 1.5;
+}
+
+.onboarding-body p {
+  margin: 0;
+}
+
+.explanation {
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+}
+
+.manual-note {
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+  padding: var(--space-sm);
+  background: var(--color-bg-secondary, rgba(0, 0, 0, 0.04));
+  border-radius: var(--radius-sm);
+}
+
+.onboarding-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-sm);
+  padding: var(--space-lg) var(--space-xl);
+  border-top: 1px solid var(--color-border);
+}
+</style>

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -707,5 +707,37 @@
     "newNoticesBody": "{count} new notice | {count} new notices",
     "connectionLostTitle": "Connection Lost",
     "connectionLostBody": "Lost connection to the BOINC client."
+  },
+  "onboarding": {
+    "takeover": {
+      "title": "Use Fresco as your BOINC manager?",
+      "lead": "We detected the official BOINC Manager set to start with your computer.",
+      "explanation": "Fresco and the BOINC Manager share the same computing engine, so only one is needed. We can turn off the Manager's autostart — your projects and progress stay untouched.",
+      "macLoginItemNote": "On this macOS version, login items must be turned off by hand. We'll open the right settings page for you.",
+      "useFrescoOnly": "Use Fresco only",
+      "keepBoth": "Keep both",
+      "successToast": "BOINC Manager autostart disabled.",
+      "manualToast": "Opened System Settings — turn off \"BOINCManager\" under Login Items.",
+      "linuxManualToast": "System-wide autostart at {path} — remove it as root to disable.",
+      "windowsHklmManualToast": "System-wide Run key \"{valueName}\" in HKLM — remove it from an elevated session to disable.",
+      "errorToast": "Could not disable BOINC Manager autostart."
+    },
+    "install": {
+      "title": "BOINC isn't installed yet",
+      "lead": "Fresco needs the BOINC computing engine to run tasks. We can set it up for you.",
+      "brewAction": "Install via Homebrew",
+      "brewInProgress": "Installing BOINC…",
+      "brewError": "Homebrew install failed. Please try again or install BOINC manually.",
+      "macosNoBrewLead": "Homebrew isn't available on this Mac. Download BOINC from the official site instead.",
+      "linuxLead": "Run this in your terminal to install the BOINC client:",
+      "linuxNoPmFallback": "No supported package manager was found. Download BOINC from the official site.",
+      "linuxCopyButton": "Copy",
+      "copied": "Command copied to clipboard.",
+      "windowsLead": "Download BOINC from the official site, then return here. Fresco will auto-connect once the client is running.",
+      "windowsManagerNote": "In the installer, uncheck \"BOINC Manager\" — Fresco replaces it.",
+      "downloadButton": "Download BOINC",
+      "showMore": "Other package managers",
+      "skip": "Skip"
+    }
   }
 }

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -707,5 +707,37 @@
     "newNoticesBody": "{count} новое уведомление | {count} новых уведомления | {count} новых уведомлений",
     "connectionLostTitle": "Соединение потеряно",
     "connectionLostBody": "Потеряно соединение с клиентом BOINC."
+  },
+  "onboarding": {
+    "takeover": {
+      "title": "Сделать Fresco вашим менеджером BOINC?",
+      "lead": "Мы обнаружили, что официальный BOINC Manager стартует вместе с системой.",
+      "explanation": "Fresco и BOINC Manager работают с одним и тем же вычислительным клиентом, второй GUI не нужен. Мы можем отключить автозапуск Manager — проекты и прогресс останутся на месте.",
+      "macLoginItemNote": "В этой версии macOS пункты автозапуска отключаются вручную. Мы откроем нужный раздел системных настроек.",
+      "useFrescoOnly": "Оставить только Fresco",
+      "keepBoth": "Оставить оба",
+      "successToast": "Автозапуск BOINC Manager отключён.",
+      "manualToast": "Открыли системные настройки — снимите «BOINCManager» в пункте автозапуска.",
+      "linuxManualToast": "Автозапуск задан на уровне системы ({path}) — удалите файл с правами root.",
+      "windowsHklmManualToast": "Системный Run-ключ «{valueName}» в HKLM — удалите его из сессии с правами администратора.",
+      "errorToast": "Не удалось отключить автозапуск BOINC Manager."
+    },
+    "install": {
+      "title": "BOINC ещё не установлен",
+      "lead": "Fresco нужен вычислительный клиент BOINC для запуска задач. Мы можем установить его за вас.",
+      "brewAction": "Установить через Homebrew",
+      "brewInProgress": "Устанавливаем BOINC…",
+      "brewError": "Не удалось установить через Homebrew. Попробуйте ещё раз или установите BOINC вручную.",
+      "macosNoBrewLead": "Homebrew не найден на этом Mac. Скачайте BOINC с официального сайта.",
+      "linuxLead": "Выполните в терминале, чтобы установить клиент BOINC:",
+      "linuxNoPmFallback": "Поддерживаемый пакетный менеджер не найден. Скачайте BOINC с официального сайта.",
+      "linuxCopyButton": "Копировать",
+      "copied": "Команда скопирована в буфер обмена.",
+      "windowsLead": "Скачайте BOINC с официального сайта и вернитесь сюда. Fresco автоматически подключится, когда клиент запустится.",
+      "windowsManagerNote": "В установщике снимите галочку «BOINC Manager» — Fresco заменяет его.",
+      "downloadButton": "Скачать BOINC",
+      "showMore": "Другие пакетные менеджеры",
+      "skip": "Пропустить"
+    }
   }
 }

--- a/src/lib/typedInvoke.ts
+++ b/src/lib/typedInvoke.ts
@@ -25,6 +25,8 @@ import type {
   DailyXferHistory,
   OldResult,
   ConnectionState,
+  ManagerAutostartInfo,
+  BoincInstallOptions,
 } from "../types/boinc";
 import type { OS, Arch } from "../composables/usePlatform";
 
@@ -72,6 +74,24 @@ interface CommandMap {
   // BOINC client launcher
   start_boinc_client: { args: { dataDir: string; clientDir: string }; ret: void };
   detect_boinc_client_dir: { args: Record<string, never>; ret: string };
+
+  // BOINC install onboarding (first run, no binary)
+  detect_boinc_install_options: {
+    args: Record<string, never>;
+    ret: BoincInstallOptions;
+  };
+  install_boinc_via_brew: { args: Record<string, never>; ret: void };
+
+  // BOINC Manager takeover (onboarding)
+  detect_boinc_manager_autostart: {
+    args: Record<string, never>;
+    ret: ManagerAutostartInfo | null;
+  };
+  disable_boinc_manager_autostart: {
+    args: { info: ManagerAutostartInfo };
+    ret: void;
+  };
+  open_login_items_settings: { args: Record<string, never>; ret: void };
 
   // Other
   run_benchmarks: { args: Record<string, never>; ret: void };

--- a/src/stores/managerSettings.test.ts
+++ b/src/stores/managerSettings.test.ts
@@ -27,6 +27,8 @@ describe("useManagerSettingsStore", () => {
     expect(store.settings.theme).toBe("system");
     expect(store.settings.showExitConfirmation).toBe(true);
     expect(store.settings.checkForUpdates).toBe(true);
+    expect(store.settings.onboardingCompleted).toBe(false);
+    expect(store.settings.installOnboardingCompleted).toBe(false);
   });
 
   it("loads saved settings from localStorage", () => {

--- a/src/stores/managerSettings.ts
+++ b/src/stores/managerSettings.ts
@@ -11,6 +11,10 @@ export interface ManagerSettings {
   minimizeToTrayOnClose: boolean;
   startMinimizedToTray: boolean;
   checkForUpdates: boolean;
+  /** Whether the user has seen the first-run BOINC Manager takeover prompt. */
+  onboardingCompleted: boolean;
+  /** Whether the user has seen the first-run "BOINC not installed" prompt. */
+  installOnboardingCompleted: boolean;
 }
 
 const STORAGE_KEY = "boinc-manager-settings";
@@ -24,6 +28,8 @@ const defaults: ManagerSettings = {
   minimizeToTrayOnClose: true,
   startMinimizedToTray: false,
   checkForUpdates: true,
+  onboardingCompleted: false,
+  installOnboardingCompleted: false,
 };
 
 async function applyTheme(theme: ManagerSettings["theme"]) {

--- a/src/types/boinc.ts
+++ b/src/types/boinc.ts
@@ -134,6 +134,36 @@ export type ConnectionState =
   | (typeof CONNECTION_STATE)[keyof typeof CONNECTION_STATE]
   | { Error: string };
 
+/**
+ * Describes a discovered autostart registration for the official BOINC Manager.
+ *
+ * Mirrors the Rust enum (serde `tag = "kind", content = "data"`). Frontend
+ * uses this to render the takeover dialog and to pass the same value back
+ * into `disable_boinc_manager_autostart` so the backend doesn't need to
+ * re-detect.
+ */
+export type ManagerAutostartInfo =
+  | { kind: "MacLaunchAgent"; data: { plist_path: string } }
+  | { kind: "MacLoginItem" }
+  | { kind: "WindowsRunKey"; data: { hive: string; value_name: string } }
+  | { kind: "WindowsStartupShortcut"; data: { lnk_path: string } }
+  | {
+      kind: "LinuxAutostart";
+      data: { desktop_path: string; system_wide: boolean };
+    };
+
+/**
+ * Hints for the first-run install onboarding when the BOINC client binary
+ * is missing. Mirrors the Rust struct returned by
+ * `detect_boinc_install_options`.
+ */
+export interface BoincInstallOptions {
+  boinc_present: boolean;
+  platform: "macos" | "linux" | "windows";
+  package_managers: string[];
+  official_download_url: string;
+}
+
 /** Sort direction constants. */
 export const SORT_DIR = {
   ASC: "asc",


### PR DESCRIPTION
## Summary

Two first-run onboarding dialogs that both live in `autoConnect`'s fallback path:

### 1. BOINC Manager takeover
When Fresco starts next to an existing BOINC Manager install, both GUIs end up in OS login items competing for the same daemon. Detect the platform-specific autostart unit and offer to disable it so Fresco becomes the sole BOINC UI.

- **macOS:** scans `~/Library/LaunchAgents` first (per-user, no-root), then system `LaunchAgents`/`LaunchDaemons` for `edu.berkeley.boinc.Manager*.plist`. Falls back to a System Settings deep-link on macOS 13+ where SMAppService Login Items replaced editable plists.
- **Windows:** scans `HKCU`/`HKLM` `Software\Microsoft\Windows\CurrentVersion\Run` for `boincmgr`, plus the per-user Startup folder for `.lnk` shortcuts. `HKLM` permission-denied on delete is mapped to a manual instructional toast.
- **Linux:** `~/.config/autostart` (editable) first, then `/etc/xdg/autostart` (system-wide — shown with instructions).

Rename-on-disable uses a `.fresco-disabled` suffix so the user can roll back by hand. Registry values are deleted after re-reading and confirming they still point at `boincmgr`. All mutating paths are validated against the expected autostart directories + filename matcher, so an XSS-compromised webview cannot use the command to rename arbitrary files.

### 2. BOINC client not installed
When the client binary is missing, `startBoincClient` now yields to a second dialog. Detect platform + available package managers (`apt`/`dnf`/`pacman` on Linux, `brew` on macOS) and either install from the UI or hand the user a copy-ready command.

- **macOS + Homebrew:** spawn `brew install boinc` via `tokio::process::Command` with `kill_on_drop(true)` and a 900-second timeout, then retry the connection.
- **Linux:** show the command for the first supported PM with a Copy button; additional PMs are behind a "Show more" toggle. No supported PM → fall back to the download button.
- **Windows:** "Download BOINC" deep-links to the official site, with a hint to uncheck Manager in the installer.
- Dedicated `installOnboardingCompleted` flag means the dialog runs at most once per user.

Also extends `resolve_boinc_exe` with `/opt/homebrew/bin/boinc` and `/usr/local/bin/boinc` so post-brew installs are discoverable.

## Test plan

- [ ] **macOS 13+ with plist:** first launch shows takeover → Use Fresco only → plist renamed + autostart unloaded.
- [ ] **macOS 15 without plist (Manager installed):** first launch offers the Login Items deep-link; clicking opens System Settings → Login Items.
- [ ] **macOS without BOINC installed + brew present:** first launch shows install dialog → Install via Homebrew → brew runs → auto-connects to /tasks.
- [ ] **macOS without BOINC and without brew:** first launch shows install dialog with Download button.
- [ ] **Windows 11 with HKCU Run entry:** takeover prompt disables the entry cleanly.
- [ ] **Windows 11 with HKLM Run entry (non-admin):** takeover shows HKLM manual instructions instead of a generic error toast.
- [ ] **Ubuntu 22.04 user autostart:** `~/.config/autostart/boinc-manager.desktop` is renamed.
- [ ] **Ubuntu system autostart:** `/etc/xdg/autostart/...` path shown in an instructional toast.
- [ ] **Linux without BOINC installed:** install dialog shows `sudo apt install boinc-client` with Copy.
- [ ] **No Manager + BOINC installed:** neither dialog fires; app goes straight to /tasks.
- [ ] **Skip install → retry later:** dialog does not reappear on next launch (localStorage flag).
- [ ] `pnpm lint`, `pnpm exec vue-tsc --noEmit`, `pnpm test` (593), `cargo clippy -- -D warnings`, `cargo test` (60) — all green.

Iterated through six rounds of Copilot review.