### PR TITLE
fix(macos): ad-hoc codesign bundle so Gatekeeper stops showing "damaged"

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -68,6 +68,7 @@
       "icons/icon.ico"
     ],
     "macOS": {
+      "signingIdentity": "-",
       "dmg": {
         "background": "icons/dmg-background.png",
         "windowSize": {


### PR DESCRIPTION
## Summary

Follow-up to #96. Users on Apple Silicon + macOS 15 still see the misleading **"Fresco.app is damaged and can't be opened. You should move it to the Trash"** dialog, even though the release now ships as a DMG. Root cause is different from #95.

## Diagnosis

On a freshly installed Fresco.app from the latest DMG:

```
$ codesign -dv --verbose=4 /Applications/Fresco.app
Format=app bundle with Mach-O thin (arm64)
CodeDirectory ... flags=0x20002(adhoc,linker-signed) ...
Info.plist=not bound
Sealed Resources=none
Signature=adhoc
```

The Mach-O binary has an ad-hoc signature from `rustc`'s linker (Apple Silicon requires this for any process to execute), **but the `.app` bundle itself is not sealed** — `Sealed Resources=none`, `Info.plist=not bound`. Gatekeeper on macOS 15 rejects unsealed bundles with the "damaged" dialog instead of the honest "unidentified developer" flow. This is orthogonal to #95 (which was about quarantine-on-zip); DMG container fixed the zip half, bundle sealing fixes the other half.

## Fix

One-line `tauri.conf.json` change:

```diff
     "macOS": {
+      "signingIdentity": "-",
       "dmg": { ... }
     }
```

When `signingIdentity` is set (even to the `"-"` pseudo-identity), Tauri bundler invokes `codesign --force --deep --sign - Fresco.app` after bundling, which:
- Generates `Contents/_CodeSignature/CodeResources` (seals all bundle files)
- Binds the `Info.plist`
- Replaces `linker-signed` with a proper bundle-level ad-hoc signature

Expected post-fix `codesign -dv` output: `Sealed Resources=bundle`, `Info.plist entries=N`, `Signature=adhoc`.

## Why not in #96

PR #96 assumed the "damaged" dialog came purely from the zipped-`.app` Gatekeeper path (per Apple's [TN3178](https://developer.apple.com/documentation/technotes/tn3178-checking-for-and-resolving-build-udids-problems) family of docs on quarantine). That's one cause, fixed by the DMG switch. The second cause — missing bundle-level seal on Apple Silicon — was not on the radar because the linker-level ad-hoc signature looks sufficient if you only check `codesign -dv` on the binary, not the bundle.

## Known limitations (unchanged)

- Still unsigned by Developer ID. First launch requires **System Settings → Privacy & Security → Open Anyway** (the canonical workaround the wiki already documents).
- Subsequent launches work normally — macOS remembers the user's approval.
- Full fix remains Developer ID + notarization (`$99/year`, tracked separately).

## References

- [Tauri v2 macOS code signing docs](https://v2.tauri.app/distribute/sign/macos/) — documents `"signingIdentity": "-"` as the canonical ad-hoc config
- [tauri-apps/tauri#8763](https://github.com/tauri-apps/tauri/issues/8763) — maintainer confirmation that ad-hoc signing "eliminates the 'app is damaged' dialog"
- [tauri-apps/tauri#13804](https://github.com/tauri-apps/tauri/issues/13804) — intermittent ad-hoc CI failures on macOS runners (rare; retry fixes); worth knowing about if this PR's CI ever flakes

## Test plan

- [ ] GitHub Actions `Build` workflow passes (both macOS matrix entries)
- [ ] After merge, the next `master` release publishes `Fresco_macOS_*.dmg` with sealed bundles
- [ ] Manual verification on Apple Silicon: install from DMG, launch Fresco → dialog says "cannot verify developer" (with "Open Anyway" path), **not** "damaged"
- [ ] `codesign -dv --verbose=4 /Applications/Fresco.app` shows `Sealed Resources=bundle` after install

## Rollback

Single-line revert in `tauri.conf.json`. No config/data migration.

Reviewed with Codex before submission.