### PR TITLE
fix(ci): require notarized macOS releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,7 +107,65 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      - name: Import Apple Developer ID certificate (release macOS)
+        if: startsWith(matrix.platform, 'macos') && github.event_name == 'push' && github.ref == 'refs/heads/master'
+        env:
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          set -euo pipefail
+
+          missing=0
+          for name in APPLE_CERTIFICATE APPLE_CERTIFICATE_PASSWORD KEYCHAIN_PASSWORD APPLE_ID APPLE_PASSWORD APPLE_TEAM_ID; do
+            if [ -z "${!name}" ]; then
+              echo "::error::$name secret is required for notarized macOS release builds."
+              missing=1
+            fi
+          done
+
+          if [ "$missing" -ne 0 ]; then
+            exit 1
+          fi
+
+          if ! printf '%s' "$APPLE_CERTIFICATE" | base64 --decode > "$RUNNER_TEMP/certificate.p12" 2>/dev/null; then
+            printf '%s' "$APPLE_CERTIFICATE" | base64 -D > "$RUNNER_TEMP/certificate.p12"
+          fi
+          security create-keychain -p "$KEYCHAIN_PASSWORD" build.keychain
+          security default-keychain -s build.keychain
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" build.keychain
+          security set-keychain-settings -t 3600 -u build.keychain
+          security import "$RUNNER_TEMP/certificate.p12" -k build.keychain -P "$APPLE_CERTIFICATE_PASSWORD" -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" build.keychain
+          security find-identity -v -p codesigning build.keychain
+
+          cert_id=$(security find-identity -v -p codesigning build.keychain | awk -F'"' '/Developer ID Application/ { print $2; exit }')
+          if [ -z "$cert_id" ]; then
+            echo "::error::No Developer ID Application identity found in APPLE_CERTIFICATE."
+            exit 1
+          fi
+
+          echo "APPLE_SIGNING_IDENTITY=$cert_id" >> "$GITHUB_ENV"
+
+      - name: Build Tauri (release macOS)
+        if: startsWith(matrix.platform, 'macos') && github.event_name == 'push' && github.ref == 'refs/heads/master'
+        uses: tauri-apps/tauri-action@v0
+        env:
+          FRESCO_BUILD_TIME: ${{ needs.lint.outputs.build_time }}
+          # Override Tauri's default "skip DMG Finder prettifying on CI" — without this
+          # the macOS DMG ships without background image and custom icon positions.
+          TAURI_BUNDLER_DMG_IGNORE_CI: true
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        with:
+          args: --target ${{ matrix.target }}
+
       - name: Build Tauri
+        if: ${{ !(startsWith(matrix.platform, 'macos') && github.event_name == 'push' && github.ref == 'refs/heads/master') }}
         uses: tauri-apps/tauri-action@v0
         env:
           FRESCO_BUILD_TIME: ${{ needs.lint.outputs.build_time }}
@@ -116,6 +174,109 @@ jobs:
           TAURI_BUNDLER_DMG_IGNORE_CI: ${{ startsWith(matrix.platform, 'macos') && 'true' || '' }}
         with:
           args: --target ${{ matrix.target }} ${{ startsWith(matrix.platform, 'windows') && '--no-bundle' || '' }}
+
+      - name: Verify macOS DMG presentation metadata
+        if: startsWith(matrix.platform, 'macos')
+        run: |
+          set -euo pipefail
+
+          dmg=$(find "src-tauri/target/${{ matrix.target }}/release/bundle/dmg" -maxdepth 1 -name '*.dmg' -type f -print -quit)
+          if [ -z "$dmg" ]; then
+            echo "::error::Built macOS DMG not found."
+            exit 1
+          fi
+
+          mountpoint=$(mktemp -d)
+          attached=0
+          cleanup() {
+            if [ "$attached" -eq 1 ]; then
+              hdiutil detach "$mountpoint" >/dev/null 2>&1 || true
+            fi
+            rm -rf "$mountpoint"
+          }
+          trap cleanup EXIT
+
+          hdiutil attach "$dmg" -nobrowse -readonly -mountpoint "$mountpoint" >/dev/null
+          attached=1
+
+          if [ ! -d "$mountpoint/Fresco.app" ]; then
+            echo "::error::Fresco.app not found inside $dmg."
+            exit 1
+          fi
+
+          if [ ! -L "$mountpoint/Applications" ]; then
+            echo "::error::Applications symlink not found inside $dmg."
+            exit 1
+          fi
+
+          if [ ! -f "$mountpoint/.background/dmg-background.png" ]; then
+            echo "::error::DMG background image not found; Finder presentation metadata likely was not generated."
+            exit 1
+          fi
+
+          if [ ! -f "$mountpoint/.DS_Store" ]; then
+            echo "::error::.DS_Store not found; Finder presentation metadata likely was not generated."
+            exit 1
+          fi
+
+          width=$(sips -g pixelWidth "$mountpoint/.background/dmg-background.png" | awk '/pixelWidth/ { print $2 }')
+          height=$(sips -g pixelHeight "$mountpoint/.background/dmg-background.png" | awk '/pixelHeight/ { print $2 }')
+          if [ "$width" != "660" ] || [ "$height" != "400" ]; then
+            echo "::error::Unexpected DMG background size: ${width}x${height}."
+            exit 1
+          fi
+
+      - name: Verify macOS release signature and notarization
+        if: startsWith(matrix.platform, 'macos') && github.event_name == 'push' && github.ref == 'refs/heads/master'
+        run: |
+          set -euo pipefail
+
+          dmg=$(find "src-tauri/target/${{ matrix.target }}/release/bundle/dmg" -maxdepth 1 -name '*.dmg' -type f -print -quit)
+          if [ -z "$dmg" ]; then
+            echo "::error::Built macOS DMG not found."
+            exit 1
+          fi
+
+          mountpoint=$(mktemp -d)
+          attached=0
+          cleanup() {
+            if [ "$attached" -eq 1 ]; then
+              hdiutil detach "$mountpoint" >/dev/null 2>&1 || true
+            fi
+            rm -rf "$mountpoint"
+          }
+          trap cleanup EXIT
+
+          hdiutil attach "$dmg" -nobrowse -readonly -mountpoint "$mountpoint" >/dev/null
+          attached=1
+
+          app=$(find "$mountpoint" -maxdepth 1 -name '*.app' -type d -print -quit)
+          if [ -z "$app" ]; then
+            echo "::error::Fresco.app not found inside $dmg."
+            exit 1
+          fi
+
+          codesign --verify --deep --strict --verbose=4 "$app"
+          codesign -dv --verbose=4 "$app" 2> "$RUNNER_TEMP/codesign-details.txt"
+
+          if grep -q '^Signature=adhoc$' "$RUNNER_TEMP/codesign-details.txt"; then
+            echo "::error::macOS release app is ad-hoc signed, not Developer ID signed."
+            exit 1
+          fi
+
+          if ! grep -q '^Authority=Developer ID Application:' "$RUNNER_TEMP/codesign-details.txt"; then
+            echo "::error::macOS release app is missing a Developer ID Application authority."
+            exit 1
+          fi
+
+          team_identifier=$(awk -F= '/^TeamIdentifier=/ { print $2; exit }' "$RUNNER_TEMP/codesign-details.txt")
+          if [ -z "$team_identifier" ] || [ "$team_identifier" = "not set" ]; then
+            echo "::error::macOS release app has no TeamIdentifier."
+            exit 1
+          fi
+
+          spctl -a -vv --type execute "$app"
+          xcrun stapler validate "$app"
 
       - name: Upload portable (Linux)
         if: startsWith(matrix.platform, 'ubuntu')
@@ -189,17 +350,10 @@ jobs:
           | Linux (x86_64) | `Fresco_Linux_x86_64.AppImage` |
           | Linux (ARM64) | `Fresco_Linux_ARM64.AppImage` |
 
-          ### First launch on macOS
+          ### macOS
 
-          Fresco is not yet signed with an Apple Developer ID, so macOS blocks the first launch.
-          Expected dialog: **"Fresco cannot be opened because the developer cannot be verified."**
-
-          1. Click **Done** in the warning.
-          2. Open **System Settings → Privacy & Security**.
-          3. Scroll to the bottom and click **Open Anyway** next to Fresco.
-          4. Confirm in the follow-up prompt.
-
-          macOS remembers the approval — subsequent launches open Fresco with a normal double-click.
+          Fresco macOS builds are Developer ID signed and notarized. If macOS still blocks launch,
+          download the current DMG again and report the exact dialog text.
 
           ---
           EOF

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -175,6 +175,30 @@ jobs:
         with:
           args: --target ${{ matrix.target }} ${{ startsWith(matrix.platform, 'windows') && '--no-bundle' || '' }}
 
+      - name: Notarize and staple macOS release DMG
+        if: startsWith(matrix.platform, 'macos') && github.event_name == 'push' && github.ref == 'refs/heads/master'
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          set -euo pipefail
+
+          dmg=$(find "src-tauri/target/${{ matrix.target }}/release/bundle/dmg" -maxdepth 1 -name '*.dmg' -type f -print -quit)
+          if [ -z "$dmg" ]; then
+            echo "::error::Built macOS DMG not found."
+            exit 1
+          fi
+
+          xcrun notarytool submit "$dmg" \
+            --apple-id "$APPLE_ID" \
+            --password "$APPLE_PASSWORD" \
+            --team-id "$APPLE_TEAM_ID" \
+            --wait
+          xcrun stapler staple "$dmg"
+          xcrun stapler validate "$dmg"
+          spctl -a -vv --type open --context context:primary-signature "$dmg"
+
       - name: Verify macOS DMG presentation metadata
         if: startsWith(matrix.platform, 'macos')
         run: |
@@ -277,6 +301,8 @@ jobs:
 
           spctl -a -vv --type execute "$app"
           xcrun stapler validate "$app"
+          xcrun stapler validate "$dmg"
+          spctl -a -vv --type open --context context:primary-signature "$dmg"
 
       - name: Upload portable (Linux)
         if: startsWith(matrix.platform, 'ubuntu')

--- a/agent_docs/development-history.md
+++ b/agent_docs/development-history.md
@@ -9,6 +9,27 @@
 
 ## Записи
 
+## [2026-05-11] - CI: fail unsigned macOS releases
+
+### Что сделано
+- Подтверждена причина Gatekeeper "Move to Trash" для `Fresco_macOS_ARM64.dmg`: опубликованный app bundle был ad-hoc signed (`TeamIdentifier=not set`) и без stapled notarization ticket.
+- Release-сборки macOS на `master` теперь требуют Apple Developer ID/notarization secrets, импортируют `Developer ID Application` certificate и передают notarization env в отдельный release-only `tauri-action`; ad-hoc `signingIdentity` fallback удалён из Tauri config.
+- Apple signing/notarization secrets не передаются в pull request/non-release builds, чтобы Tauri не пытался импортировать пустые `APPLE_CERTIFICATE*` значения и чтобы Linux/Windows release builds не получали лишние секреты.
+- Добавлена CI-проверка DMG: монтирует артефакт, проверяет `codesign`, Developer ID authority, TeamIdentifier, `spctl` и `xcrun stapler validate`.
+- Добавлена CI-проверка macOS DMG presentation metadata: `.DS_Store`, background image, `Applications` symlink и ожидаемый background size, чтобы не публиковать DMG без Finder layout.
+- Подключён `Entitlements.plist` для hardened runtime WebKit/JSC и сетевых возможностей.
+- Release notes больше не описывают ручной Gatekeeper workaround для новых macOS релизов.
+
+### Зачем
+Silent fallback на ad-hoc подпись создавал успешный GitHub release, который чистая macOS блокировала как повреждённый. Теперь релиз не должен публиковаться, если macOS артефакт не Developer ID signed и notarized.
+
+### Обновлено
+- [x] Root cause подтверждён на опубликованном ARM DMG.
+- [x] Проверки: `git diff --check`, JSON/YAML parse, `pnpm lint`, `pnpm test` (620).
+- [x] `agent_docs/development-history.md`
+- [ ] CI release signing требует Apple secrets в GitHub; локально notarized build без них не воспроизводится.
+- [ ] `agent_docs/adr.md` — не требуется, это release pipeline guard.
+
 ## [2026-05-10] - CI: allow pnpm build script for @parcel/watcher
 
 ### Что сделано

--- a/agent_docs/development-history.md
+++ b/agent_docs/development-history.md
@@ -15,7 +15,7 @@
 - Подтверждена причина Gatekeeper "Move to Trash" для `Fresco_macOS_ARM64.dmg`: опубликованный app bundle был ad-hoc signed (`TeamIdentifier=not set`) и без stapled notarization ticket.
 - Release-сборки macOS на `master` теперь требуют Apple Developer ID/notarization secrets, импортируют `Developer ID Application` certificate и передают notarization env в отдельный release-only `tauri-action`; ad-hoc `signingIdentity` fallback удалён из Tauri config.
 - Apple signing/notarization secrets не передаются в pull request/non-release builds, чтобы Tauri не пытался импортировать пустые `APPLE_CERTIFICATE*` значения и чтобы Linux/Windows release builds не получали лишние секреты.
-- Добавлена CI-проверка DMG: монтирует артефакт, проверяет `codesign`, Developer ID authority, TeamIdentifier, `spctl` и `xcrun stapler validate`.
+- Release-сборка macOS теперь дополнительно notarize/staple сам `.dmg`, а CI проверяет Gatekeeper/notarization и для app bundle внутри образа, и для скачиваемого DMG-контейнера.
 - Добавлена CI-проверка macOS DMG presentation metadata: `.DS_Store`, background image, `Applications` symlink и ожидаемый background size, чтобы не публиковать DMG без Finder layout.
 - Подключён `Entitlements.plist` для hardened runtime WebKit/JSC и сетевых возможностей.
 - Release notes больше не описывают ручной Gatekeeper workaround для новых macOS релизов.

--- a/src-tauri/Entitlements.plist
+++ b/src-tauri/Entitlements.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.network.client</key>
+    <true/>
+    <key>com.apple.security.network.server</key>
+    <true/>
+</dict>
+</plist>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -68,7 +68,7 @@
       "icons/icon.ico"
     ],
     "macOS": {
-      "signingIdentity": "-",
+      "entitlements": "Entitlements.plist",
       "dmg": {
         "background": "icons/dmg-background.png",
         "windowSize": {


### PR DESCRIPTION
## Summary
- Fail macOS release builds when Apple Developer ID / notarization secrets are missing instead of silently publishing ad-hoc signed DMGs.
- Import the Developer ID Application certificate for macOS release jobs and verify the final DMG contents with `codesign`, `spctl`, and `xcrun stapler validate` before upload.
- Add a macOS DMG presentation guard so CI verifies the app alias, Applications symlink, background image, `.DS_Store`, and expected 660x400 background size.
- Scope Apple signing/notarization secrets to macOS release jobs only, add hardened-runtime entitlements, and update release notes for notarized macOS builds.

## Maintainer setup required
Before merging and publishing the next `latest` release, please add these repository secrets in `AufarZakiev/Fresco`:

- `APPLE_CERTIFICATE`: base64-encoded exported `.p12` for a **Developer ID Application** certificate
- `APPLE_CERTIFICATE_PASSWORD`: password for that `.p12`
- `KEYCHAIN_PASSWORD`: temporary CI keychain password
- `APPLE_ID`: Apple ID email used for notarization
- `APPLE_PASSWORD`: app-specific password for that Apple ID
- `APPLE_TEAM_ID`: Apple Developer Team ID

Without these secrets, the macOS release job will fail intentionally. That is preferable to publishing a DMG that a clean macOS install rejects with the "Move to Trash" Gatekeeper flow.

## Root cause checked
The current published `Fresco_macOS_ARM64.dmg` was inspected locally:

- DMG `spctl`: rejected, `source=no usable signature`
- `Fresco.app`: `Signature=adhoc`, `TeamIdentifier=not set`
- `xcrun stapler validate`: no notarization ticket

## Test plan
- [x] `git diff --check`
- [x] YAML parse for `.github/workflows/build.yml`
- [x] `pnpm lint`
- [x] `pnpm exec vue-tsc --noEmit`
- [x] `pnpm test` (620 frontend tests)
- [x] Rust tests via pre-commit hook (72 tests)
- [x] GitHub Actions Build on PR head `16b23ef` (lint + all Linux/macOS/Windows matrix jobs)
- [x] macOS DMG presentation metadata check passed for both macOS PR builds

Reviewed before submission.